### PR TITLE
Fix tagpr workflow to use GH_PAT for checkout

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -13,6 +13,8 @@ jobs:
       actions: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_PAT }}
       - uses: Songmu/tagpr@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
## Description

Fix tagpr workflow to properly trigger release workflows by using GH_PAT for checkout action.

## Type of Change

Please add the appropriate label(s) to this PR and check the relevant box(es):

- [x] 🐛 \ - Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ \ - New feature (non-breaking change which adds functionality)  
- [ ] 💥 \ - Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 \ - Documentation update
- [ ] ⚡ \ - Performance improvement
- [ ] 🔨 \ - Code refactoring
- [ ] 🧪 \ - Adding or updating tests
- [ ] 🔧 \ - Maintenance, dependencies, tooling

## Changes Made

- Add \ parameter to actions/checkout in tagpr workflow
- Required for tagpr to trigger other workflows (like release.yml) when creating tags
- Ensures proper workflow integration and automated release process

## Testing

- [x] Code is formatted (\cd frontend && npm run format

> frontend@0.0.0 format
> prettier --write src/

src/App.test.tsx 85ms (unchanged)
src/App.tsx 18ms (unchanged)
src/components/MessageComponents.tsx 4ms (unchanged)
src/hooks/useClaudeStreaming.ts 12ms (unchanged)
src/hooks/useTheme.ts 2ms (unchanged)
src/index.css 26ms (unchanged)
src/main.tsx 1ms (unchanged)
src/test-setup.ts 2ms (unchanged)
src/types.ts 5ms (unchanged)
src/vite-env.d.ts 1ms (unchanged)
cd backend && deno task format)
- [x] Manual testing: After merge, next release should trigger release.yml workflow

## Background

Currently v0.1.4 release was created by tagpr but the release.yml workflow was not triggered to build binaries. This is because the default GITHUB_TOKEN used by actions/checkout cannot trigger other workflows for security reasons. Using GH_PAT resolves this limitation.

## Additional Notes

This fixes the issue where tagpr creates releases but binary assets are not automatically built and attached.