### PR TITLE
Fix streaming state bug and update backend dependencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,9 @@ This project consists of three main components:
 - Parses different Claude JSON message types (system, assistant, result)
 - TailwindCSS utility-first styling for responsive design
 - Light/dark theme toggle with system preference detection and localStorage persistence
+- Bottom-to-top message flow layout (messages start at bottom like modern chat apps)
+- Auto-scroll to bottom with smart scroll detection (only auto-scrolls when user is near bottom)
+- Accessibility features with ARIA attributes for screen readers
 - Responsive chat interface
 - Comprehensive component testing with Vitest and Testing Library
 

--- a/backend/deno.json
+++ b/backend/deno.json
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "dev": "deno run --allow-net --allow-run --allow-read --allow-env --watch main.ts -- --debug",
+    "dev": "deno run --allow-net --allow-run --allow-read --allow-env --watch main.ts --debug",
     "build": "deno compile --allow-net --allow-run --allow-read --allow-env --include ./VERSION --include ./dist --output ../dist/claude-code-webui main.ts",
     "format": "deno fmt",
     "lint": "deno lint",

--- a/backend/deno.lock
+++ b/backend/deno.lock
@@ -3,7 +3,7 @@
   "specifiers": {
     "jsr:@hono/hono@4": "4.7.11",
     "jsr:@std/cli@1": "1.0.19",
-    "npm:@anthropic-ai/claude-code@*": "1.0.22"
+    "npm:@anthropic-ai/claude-code@1.0.24": "1.0.24"
   },
   "jsr": {
     "@hono/hono@4.7.11": {
@@ -14,8 +14,8 @@
     }
   },
   "npm": {
-    "@anthropic-ai/claude-code@1.0.22": {
-      "integrity": "sha512-vqfDHq4KNtUzUiwdsls8+2aTrC1Rn96iH+yOyCrBjHjJwojzU6pt3MOAMkJHMeErKeGqve+I7HM6mFw0OgZgqw==",
+    "@anthropic-ai/claude-code@1.0.24": {
+      "integrity": "sha512-4S6ly2297ngNlto7IFZeEicS9u0yRDhocOzndWFovGBb+iUoEPKdZa/rhVk/tcyCADL6S+mMkiGQOlqFDrN3JQ==",
       "optionalDependencies": [
         "@img/sharp-darwin-arm64",
         "@img/sharp-darwin-x64",

--- a/backend/main.ts
+++ b/backend/main.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { serveStatic } from "hono/deno";
-import { query } from "npm:@anthropic-ai/claude-code";
+import { query } from "npm:@anthropic-ai/claude-code@1.0.24";
 import type { ChatRequest, StreamResponse } from "../shared/types.ts";
 import {
   isDebugMode,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -92,6 +92,7 @@ function App() {
     setMessages((prev) => [...prev, userMessage]);
     setInput("");
     setIsLoading(true);
+    setCurrentAssistantMessage(null);
 
     try {
       const response = await fetch("http://localhost:8080/api/chat", {
@@ -106,7 +107,7 @@ function App() {
       const decoder = new TextDecoder();
 
       const streamingContext = {
-        currentAssistantMessage,
+        currentAssistantMessage: null,
         setCurrentAssistantMessage,
         addMessage: (msg: AllMessage) => {
           setMessages((prev) => [...prev, msg]);

--- a/frontend/src/hooks/useClaudeStreaming.ts
+++ b/frontend/src/hooks/useClaudeStreaming.ts
@@ -36,7 +36,7 @@ function isClaudeSystemMessage(data: unknown): data is ClaudeSystemData {
 }
 
 function isClaudeAssistantMessage(
-  data: unknown,
+  data: unknown
 ): data is ClaudeAssistantMessage {
   return (
     typeof data === "object" &&
@@ -78,7 +78,7 @@ export function useClaudeStreaming() {
         timestamp: Date.now(),
       };
     },
-    [],
+    []
   );
 
   const createToolMessage = useCallback(
@@ -100,7 +100,7 @@ export function useClaudeStreaming() {
         timestamp: Date.now(),
       };
     },
-    [],
+    []
   );
 
   const createResultMessage = useCallback(
@@ -113,7 +113,7 @@ export function useClaudeStreaming() {
         timestamp: Date.now(),
       };
     },
-    [],
+    []
   );
 
   const handleSystemMessage = useCallback(
@@ -121,7 +121,7 @@ export function useClaudeStreaming() {
       const systemMessage = createSystemMessage(claudeData);
       context.addMessage(systemMessage);
     },
-    [createSystemMessage],
+    [createSystemMessage]
   );
 
   const handleAssistantTextMessage = useCallback(
@@ -150,7 +150,7 @@ export function useClaudeStreaming() {
       context.setCurrentAssistantMessage(updatedMessage);
       context.updateLastMessage(updatedContent);
     },
-    [],
+    []
   );
 
   const handleToolUseMessage = useCallback(
@@ -159,12 +159,12 @@ export function useClaudeStreaming() {
         name?: string;
         input?: { description?: string; command?: string };
       },
-      context: StreamingContext,
+      context: StreamingContext
     ) => {
       const toolMessage = createToolMessage(contentItem);
       context.addMessage(toolMessage);
     },
-    [createToolMessage],
+    [createToolMessage]
   );
 
   const handleAssistantMessage = useCallback(
@@ -177,7 +177,7 @@ export function useClaudeStreaming() {
         }
       }
     },
-    [handleAssistantTextMessage, handleToolUseMessage],
+    [handleAssistantTextMessage, handleToolUseMessage]
   );
 
   const handleResultMessage = useCallback(
@@ -186,7 +186,7 @@ export function useClaudeStreaming() {
       context.addMessage(resultMessage);
       context.setCurrentAssistantMessage(null);
     },
-    [createResultMessage],
+    [createResultMessage]
   );
 
   const processClaudeData = useCallback(
@@ -226,7 +226,7 @@ export function useClaudeStreaming() {
           console.log("Unknown Claude message type:", claudeData.type);
       }
     },
-    [handleSystemMessage, handleAssistantMessage, handleResultMessage],
+    [handleSystemMessage, handleAssistantMessage, handleResultMessage]
   );
 
   const processStreamLine = useCallback(
@@ -253,7 +253,7 @@ export function useClaudeStreaming() {
         console.error("Failed to parse stream line:", parseError);
       }
     },
-    [processClaudeData],
+    [processClaudeData]
   );
 
   return {

--- a/frontend/src/hooks/useClaudeStreaming.ts
+++ b/frontend/src/hooks/useClaudeStreaming.ts
@@ -36,7 +36,7 @@ function isClaudeSystemMessage(data: unknown): data is ClaudeSystemData {
 }
 
 function isClaudeAssistantMessage(
-  data: unknown
+  data: unknown,
 ): data is ClaudeAssistantMessage {
   return (
     typeof data === "object" &&
@@ -78,7 +78,7 @@ export function useClaudeStreaming() {
         timestamp: Date.now(),
       };
     },
-    []
+    [],
   );
 
   const createToolMessage = useCallback(
@@ -100,7 +100,7 @@ export function useClaudeStreaming() {
         timestamp: Date.now(),
       };
     },
-    []
+    [],
   );
 
   const createResultMessage = useCallback(
@@ -113,7 +113,7 @@ export function useClaudeStreaming() {
         timestamp: Date.now(),
       };
     },
-    []
+    [],
   );
 
   const handleSystemMessage = useCallback(
@@ -121,7 +121,7 @@ export function useClaudeStreaming() {
       const systemMessage = createSystemMessage(claudeData);
       context.addMessage(systemMessage);
     },
-    [createSystemMessage]
+    [createSystemMessage],
   );
 
   const handleAssistantTextMessage = useCallback(
@@ -150,7 +150,7 @@ export function useClaudeStreaming() {
       context.setCurrentAssistantMessage(updatedMessage);
       context.updateLastMessage(updatedContent);
     },
-    []
+    [],
   );
 
   const handleToolUseMessage = useCallback(
@@ -159,12 +159,12 @@ export function useClaudeStreaming() {
         name?: string;
         input?: { description?: string; command?: string };
       },
-      context: StreamingContext
+      context: StreamingContext,
     ) => {
       const toolMessage = createToolMessage(contentItem);
       context.addMessage(toolMessage);
     },
-    [createToolMessage]
+    [createToolMessage],
   );
 
   const handleAssistantMessage = useCallback(
@@ -177,7 +177,7 @@ export function useClaudeStreaming() {
         }
       }
     },
-    [handleAssistantTextMessage, handleToolUseMessage]
+    [handleAssistantTextMessage, handleToolUseMessage],
   );
 
   const handleResultMessage = useCallback(
@@ -186,7 +186,7 @@ export function useClaudeStreaming() {
       context.addMessage(resultMessage);
       context.setCurrentAssistantMessage(null);
     },
-    [createResultMessage]
+    [createResultMessage],
   );
 
   const processClaudeData = useCallback(
@@ -226,7 +226,7 @@ export function useClaudeStreaming() {
           console.log("Unknown Claude message type:", claudeData.type);
       }
     },
-    [handleSystemMessage, handleAssistantMessage, handleResultMessage]
+    [handleSystemMessage, handleAssistantMessage, handleResultMessage],
   );
 
   const processStreamLine = useCallback(
@@ -253,7 +253,7 @@ export function useClaudeStreaming() {
         console.error("Failed to parse stream line:", parseError);
       }
     },
-    [processClaudeData]
+    [processClaudeData],
   );
 
   return {


### PR DESCRIPTION
## Type of Change

- [x] 🐛 `bug` - Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ `feature` - New feature (non-breaking change which adds functionality)
- [ ] 💥 `breaking` - Breaking change
- [x] 📚 `documentation` - Documentation update
- [ ] ⚡ `performance` - Performance improvement
- [ ] 🔨 `refactor` - Code refactoring
- [ ] 🧪 `test` - Adding or updating tests
- [x] 🔧 `chore` - Maintenance, dependencies, tooling

## Summary

This PR addresses multiple issues and improvements:

- 🐛 **Frontend Bug Fix**: Resolves critical streaming state issue where assistant messages from different conversations were being concatenated
- 🔧 **Backend Updates**: Fixes debug flag handling and updates claude-code SDK to latest version  
- 📚 **Documentation**: Updates project documentation to reflect current frontend features

## Changes

### Frontend Bug Fix (`fix(frontend)`)
- Fixed `currentAssistantMessage` state not resetting between conversations
- Resolved issue where typing "1+1=?" followed by "2+2=?" would show "24" instead of "4"
- Ensured streaming context starts fresh for each new chat request
- Cleaned up debugging code and improved code formatting

### Backend Updates (`fix(backend)`)
- Fixed deno task dev command to properly pass `--debug` flag without `--` separator
- Updated claude-code SDK from 1.0.22 to 1.0.24 for latest features and bug fixes
- Improved debug mode functionality in development environment

### Documentation (`docs`)
- Added documentation for bottom-to-top message flow layout
- Documented auto-scroll functionality with smart scroll detection  
- Added accessibility features documentation
- Updated CLAUDE.md to reflect current frontend capabilities

## Test Plan

- [x] Verify multiple consecutive chat messages display correctly
- [x] Test debug mode works in backend development (`deno task dev`)
- [x] Confirm streaming messages work properly without concatenation
- [x] Validate documentation accuracy

🤖 Generated with [Claude Code](https://claude.ai/code)