### PR TITLE
Remove Windows support since @anthropic-ai/claude-code doesn't support Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,6 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
             artifact_name: claude-code-webui-macos-arm64
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            artifact_name: claude-code-webui-windows-x64.exe
 
     steps:
       - name: Checkout code
@@ -51,14 +48,7 @@ jobs:
         run: npm run build
         working-directory: frontend
 
-      - name: Copy frontend dist to backend (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          Remove-Item -Path backend/dist -Force -Recurse -ErrorAction SilentlyContinue
-          Copy-Item -Path frontend/dist -Destination backend/dist -Recurse
-
-      - name: Copy frontend dist to backend (Unix)
-        if: runner.os != 'Windows'
+      - name: Copy frontend dist to backend
         run: |
           rm -rf backend/dist
           cp -r frontend/dist backend/dist

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,7 @@ cd backend && deno task build
 ### Automated Releases
 
 - **Trigger**: Push git tags (e.g., `git tag v1.0.0 && git push origin v1.0.0`)
-- **Platforms**: Linux (x64/ARM64), macOS (x64/ARM64), Windows (x64)
+- **Platforms**: Linux (x64/ARM64), macOS (x64/ARM64)
 - **Output**: GitHub Releases with downloadable binaries
 - **Features**: Frontend is automatically bundled into each binary
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Download the latest pre-built binary for your platform from [Releases](https://g
 
 - **Linux**: `claude-code-webui-linux-x64`, `claude-code-webui-linux-arm64`
 - **macOS**: `claude-code-webui-macos-x64`, `claude-code-webui-macos-arm64`
-- **Windows**: `claude-code-webui-windows-x64.exe`
 
 ```bash
 # Example for macOS ARM64


### PR DESCRIPTION
## Summary

- Remove Windows build configuration from GitHub Actions workflow
- Remove Windows-specific PowerShell commands in favor of Unix-only approach
- Update documentation to remove Windows binary references
- Simplify build process by removing cross-platform complexity

## Background

The `@anthropic-ai/claude-code` package doesn't support Windows, so maintaining Windows build configurations and cross-platform compatibility code is unnecessary.

## Changes

- ✅ Remove Windows build matrix entry from `.github/workflows/release.yml`
- ✅ Replace Windows/Unix conditional file copying with Unix-only commands
- ✅ Update `README.md` to remove Windows binary references
- ✅ Update `CLAUDE.md` to remove Windows platform mention
- ✅ Add comment to issue #20 explaining Windows compatibility is no longer needed

## Impact

This is a **breaking change** for Windows users, but since the underlying Claude CLI doesn't support Windows anyway, this aligns the project with its actual capabilities.

🤖 Generated with [Claude Code](https://claude.ai/code)