### PR TITLE
feat: Show 'Claude Code initialized' message only once per session

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ function App() {
   const [input, setInput] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [currentSessionId, setCurrentSessionId] = useState<string | null>(null);
+  const [hasShownInitMessage, setHasShownInitMessage] = useState(false);
   const { theme, toggleTheme } = useTheme();
   const { processStreamLine } = useClaudeStreaming();
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -127,6 +128,10 @@ function App() {
         },
         onSessionId: (sessionId: string) => {
           setCurrentSessionId(sessionId);
+        },
+        shouldShowInitMessage: () => !hasShownInitMessage,
+        onInitMessageShown: () => {
+          setHasShownInitMessage(true);
         },
       };
 


### PR DESCRIPTION
## Type of Change
- [ ] 🐛 `bug` - Bug fix (non-breaking change which fixes an issue)
- [x] ✨ `feature` - New feature (non-breaking change which adds functionality)
- [ ] 💥 `breaking` - Breaking change
- [ ] 📚 `documentation` - Documentation update
- [ ] ⚡ `performance` - Performance improvement
- [ ] 🔨 `refactor` - Code refactoring
- [ ] 🧪 `test` - Adding or updating tests
- [ ] 🔧 `chore` - Maintenance, dependencies, tooling

## Summary
- Shows the "Claude Code initialized" system message only once per chat session
- Prevents repetitive initialization messages in the same conversation
- Improves chat UI cleanliness and user experience

## Changes
- Added `hasShownInitMessage` state to track initialization message display
- Extended `StreamingContext` interface with init message control callbacks
- Modified `handleSystemMessage` to conditionally show init messages based on session state
- Non-init system messages (like task completion) continue to show normally

## Test plan
- [x] Start a new chat session - initialization message appears
- [ ] Send multiple messages in the same session - initialization message does not repeat
- [ ] Verify other system messages (task completion, errors) still display correctly
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)