### PR TITLE
feat: Add timestamps to chat messages

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
+        "dayjs": "^1.11.13",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -2849,6 +2850,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
+    "dayjs": "^1.11.13",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/frontend/src/components/MessageComponents.tsx
+++ b/frontend/src/components/MessageComponents.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { ChatMessage, SystemMessage, ToolMessage } from "../types";
+import { formatRelativeTime } from "../utils/time";
 
 interface BubbleContainerProps {
   alignment: "left" | "right" | "center";
@@ -45,12 +46,21 @@ export function ChatMessageComponent({ message }: ChatMessageComponentProps) {
       alignment={isUser ? "right" : "left"}
       colorScheme={colorScheme}
     >
-      <div
-        className={`text-xs font-semibold mb-2 opacity-90 ${
-          isUser ? "text-blue-100" : "text-slate-600 dark:text-slate-400"
-        }`}
-      >
-        {isUser ? "You" : "Assistant"}
+      <div className="mb-2">
+        <div
+          className={`text-xs font-semibold opacity-90 ${
+            isUser ? "text-blue-100" : "text-slate-600 dark:text-slate-400"
+          }`}
+        >
+          {isUser ? "You" : "Assistant"}
+        </div>
+        <div
+          className={`text-xs opacity-70 ${
+            isUser ? "text-blue-200" : "text-slate-500 dark:text-slate-500"
+          }`}
+        >
+          {formatRelativeTime(message.timestamp)}
+        </div>
       </div>
       <pre className="whitespace-pre-wrap text-sm font-mono leading-relaxed">
         {message.content}
@@ -68,11 +78,16 @@ export function SystemMessageComponent({
 }: SystemMessageComponentProps) {
   return (
     <div className="mb-3 p-3 rounded-lg bg-blue-50/80 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800">
-      <div className="text-blue-800 dark:text-blue-300 text-xs font-medium mb-1 flex items-center gap-2">
-        <div className="w-4 h-4 bg-blue-400 dark:bg-blue-500 rounded-full flex items-center justify-center text-white text-xs">
-          ⚙
+      <div className="text-blue-800 dark:text-blue-300 text-xs font-medium mb-1">
+        <div className="flex items-center gap-2">
+          <div className="w-4 h-4 bg-blue-400 dark:bg-blue-500 rounded-full flex items-center justify-center text-white text-xs">
+            ⚙
+          </div>
+          System
         </div>
-        System
+        <div className="text-blue-600 dark:text-blue-400 opacity-70 mt-1">
+          {formatRelativeTime(message.timestamp)}
+        </div>
       </div>
       <pre className="whitespace-pre-wrap text-blue-700 dark:text-blue-300 text-xs font-mono leading-relaxed">
         {message.content}
@@ -91,11 +106,16 @@ export function ToolMessageComponent({ message }: ToolMessageComponentProps) {
       alignment="left"
       colorScheme="bg-emerald-100 dark:bg-emerald-900 text-emerald-800 dark:text-emerald-100"
     >
-      <div className="text-xs font-semibold mb-2 opacity-90 text-emerald-700 dark:text-emerald-300 flex items-center gap-2">
-        <div className="w-4 h-4 bg-emerald-500 dark:bg-emerald-600 rounded-full flex items-center justify-center text-white text-xs">
-          🔧
+      <div className="text-xs font-semibold mb-2 opacity-90 text-emerald-700 dark:text-emerald-300">
+        <div className="flex items-center gap-2">
+          <div className="w-4 h-4 bg-emerald-500 dark:bg-emerald-600 rounded-full flex items-center justify-center text-white text-xs">
+            🔧
+          </div>
+          Tool
         </div>
-        Tool
+        <div className="text-emerald-600 dark:text-emerald-400 opacity-70 mt-1">
+          {formatRelativeTime(message.timestamp)}
+        </div>
       </div>
       <pre className="whitespace-pre-wrap text-xs font-mono leading-relaxed">
         {message.content}

--- a/frontend/src/utils/time.ts
+++ b/frontend/src/utils/time.ts
@@ -1,0 +1,24 @@
+import dayjs from "dayjs";
+
+/**
+ * Format a timestamp as a readable time string
+ * @param timestamp - Unix timestamp in milliseconds
+ * @returns Formatted time string (e.g., "14:30", "Dec 15, 14:30")
+ */
+export function formatRelativeTime(timestamp: number): string {
+  const messageTime = dayjs(timestamp);
+  const now = dayjs();
+
+  // If it's today, show only time (HH:mm)
+  if (messageTime.isSame(now, "day")) {
+    return messageTime.format("HH:mm");
+  }
+
+  // If it's this year, show date and time without year
+  if (messageTime.isSame(now, "year")) {
+    return messageTime.format("MMM D, HH:mm");
+  }
+
+  // If it's from a different year, show full date and time
+  return messageTime.format("MMM D, YYYY HH:mm");
+}


### PR DESCRIPTION
## Summary

- ✨ Add timestamp display to all chat messages (user, assistant, system, tool)
- 📅 Use absolute time format instead of relative time to avoid "just now" confusion
- 🎨 Consistent styling with existing design system

## Changes

### Time Formatting Strategy
- **Today**: Show only time (e.g., "14:30")
- **This year**: Show date and time (e.g., "Dec 15, 14:30") 
- **Other years**: Show full date (e.g., "Dec 15, 2023 14:30")

### Technical Implementation
- Added `dayjs` dependency for reliable cross-platform date handling
- Created `utils/time.ts` with `formatRelativeTime()` function
- Updated all message components to display timestamps below sender names
- Applied consistent styling with 70% opacity in both light/dark themes

### Files Modified
- `frontend/package.json` - Added dayjs dependency
- `frontend/src/utils/time.ts` - New time formatting utility
- `frontend/src/components/MessageComponents.tsx` - Added timestamp display to all message types

## Type of Change

- [x] ✨ `feature` - New feature (non-breaking change which adds functionality)
- [ ] 🐛 `bug` - Bug fix (non-breaking change which fixes an issue)
- [ ] 💥 `breaking` - Breaking change
- [ ] 📚 `documentation` - Documentation update
- [ ] ⚡ `performance` - Performance improvement
- [ ] 🔨 `refactor` - Code refactoring
- [ ] 🧪 `test` - Adding or updating tests
- [ ] 🔧 `chore` - Maintenance, dependencies, tooling

## Test Plan

- [x] Timestamps display correctly for all message types
- [x] Time format adapts based on message age (today/this year/other years)
- [x] Styling consistent in both light and dark themes
- [x] No TypeScript errors
- [x] All linting and formatting checks pass

Resolves #23

🤖 Generated with [Claude Code](https://claude.ai/code)