### PR TITLE
feat: simplify system messages with collapsible details

### DIFF
--- a/frontend/src/components/MessageComponents.tsx
+++ b/frontend/src/components/MessageComponents.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import type { ChatMessage, SystemMessage, ToolMessage } from "../types";
 import { TimestampComponent } from "./TimestampComponent";
 
@@ -75,17 +75,30 @@ interface SystemMessageComponentProps {
 export function SystemMessageComponent({
   message,
 }: SystemMessageComponentProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const hasDetails = message.details && message.details.trim().length > 0;
+
   return (
     <div className="mb-3 p-3 rounded-lg bg-blue-50/80 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800">
-      <div className="text-blue-800 dark:text-blue-300 text-xs font-medium mb-1 flex items-center gap-2">
+      <div
+        className={`text-blue-800 dark:text-blue-300 text-xs font-medium mb-1 flex items-center gap-2 ${hasDetails ? "cursor-pointer hover:text-blue-600 dark:hover:text-blue-200" : ""}`}
+        onClick={hasDetails ? () => setIsExpanded(!isExpanded) : undefined}
+      >
         <div className="w-4 h-4 bg-blue-400 dark:bg-blue-500 rounded-full flex items-center justify-center text-white text-xs">
           ⚙
         </div>
-        System
+        <span>{message.summary}</span>
+        {hasDetails && (
+          <span className="ml-1 text-blue-600 dark:text-blue-400">
+            {isExpanded ? "▼" : "▶"}
+          </span>
+        )}
       </div>
-      <pre className="whitespace-pre-wrap text-blue-700 dark:text-blue-300 text-xs font-mono leading-relaxed">
-        {message.content}
-      </pre>
+      {hasDetails && isExpanded && (
+        <pre className="whitespace-pre-wrap text-blue-700 dark:text-blue-300 text-xs font-mono leading-relaxed mt-2 pl-6 border-l-2 border-blue-200 dark:border-blue-700">
+          {message.details}
+        </pre>
+      )}
     </div>
   );
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -7,7 +7,8 @@ export interface ChatMessage {
 
 export type SystemMessage = {
   type: "system";
-  content: string;
+  summary: string;
+  details?: string;
   timestamp: number;
 };
 


### PR DESCRIPTION
## Summary

Simplifies system messages by displaying only subtypes (e.g., "init", "success") with collapsible details sections, addressing the UI clutter issue described in #45.

## Changes

- **Use subtypes directly**: Display actual subtype names instead of verbose text like "🔧 Claude Code initialized"
- **Collapsible details**: System messages now show summary by default with click-to-expand details  
- **Type system updates**: Modified `SystemMessage` type to separate `summary` and `details` fields
- **Performance-conscious**: No animations to support potential bulk expand/collapse operations
- **CWD support**: Init messages now include current working directory information when available

## Example

**Before:**
```
🔧 Claude Code initialized
Model: claude-3-5-sonnet-20241022
Session: abc12345
Tools: 15 available
```

**After:**
```
init ▶
  [Click to expand details]
```

**Expanded:**
```
init ▼
Model: claude-3-5-sonnet-20241022
Session: abc12345  
Tools: 15 available
CWD: /path/to/project
```

## Type of Change

- [x] ✨ `feature` - New feature (non-breaking change which adds functionality)
- [ ] 🐛 `bug` - Bug fix (non-breaking change which fixes an issue)
- [ ] 💥 `breaking` - Breaking change
- [ ] 📚 `documentation` - Documentation update
- [ ] ⚡ `performance` - Performance improvement
- [ ] 🔨 `refactor` - Code refactoring
- [ ] 🧪 `test` - Adding or updating tests
- [ ] 🔧 `chore` - Maintenance, dependencies, tooling

## Test Plan

- [x] System messages display as subtypes only by default
- [x] Details are hidden by default and expandable on click
- [x] TypeScript compilation passes without errors
- [x] Linting and formatting checks pass
- [x] UI maintains consistent styling and accessibility

Closes #45

🤖 Generated with [Claude Code](https://claude.ai/code)