### PR TITLE
feat: add abort functionality for streaming responses

### DIFF
--- a/backend/main.ts
+++ b/backend/main.ts
@@ -90,7 +90,7 @@ async function* executeClaudeCommand(
     yield { type: "done" };
   } catch (error) {
     // Check if error is due to abort
-    if (error instanceof Error && error.name === "AbortError") {
+    if (error instanceof Error && error.message.includes("aborted by user")) {
       yield { type: "aborted" };
     } else {
       yield {
@@ -148,6 +148,13 @@ app.post("/api/abort/:requestId", (c) => {
 
 app.post("/api/chat", async (c) => {
   const chatRequest: ChatRequest = await c.req.json();
+
+  if (DEBUG_MODE) {
+    console.debug(
+      "[DEBUG] Received chat request:",
+      JSON.stringify(chatRequest, null, 2),
+    );
+  }
 
   const stream = new ReadableStream({
     async start(controller) {

--- a/backend/main.ts
+++ b/backend/main.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { serveStatic } from "hono/deno";
-import { query } from "npm:@anthropic-ai/claude-code@1.0.24";
+import { AbortError, query } from "npm:@anthropic-ai/claude-code@1.0.24";
 import type { ChatRequest, StreamResponse } from "../shared/types.ts";
 import {
   isDebugMode,
@@ -90,7 +90,7 @@ async function* executeClaudeCommand(
     yield { type: "done" };
   } catch (error) {
     // Check if error is due to abort
-    if (error instanceof Error && error.message.includes("aborted by user")) {
+    if (error instanceof AbortError) {
       yield { type: "aborted" };
     } else {
       yield {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -82,7 +82,7 @@ describe("App", () => {
         expect.objectContaining({
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ message: "First message" }),
+          body: expect.stringMatching(/"message":"First message".*"requestId":"[a-f0-9-]{36}"/),
         }),
       );
     });

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -82,7 +82,9 @@ describe("App", () => {
         expect.objectContaining({
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: expect.stringMatching(/"message":"First message".*"requestId":"[a-f0-9-]{36}"/),
+          body: expect.stringMatching(
+            /"message":"First message".*"requestId":"[a-f0-9-]{36}"/,
+          ),
         }),
       );
     });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,7 +8,8 @@ import {
 } from "./types";
 import { useTheme } from "./hooks/useTheme";
 import { useClaudeStreaming } from "./hooks/useClaudeStreaming";
-import { SunIcon, MoonIcon, StopIcon } from "@heroicons/react/24/outline";
+import { SunIcon, MoonIcon } from "@heroicons/react/24/outline";
+import { StopIcon } from "@heroicons/react/24/solid";
 import {
   ChatMessageComponent,
   SystemMessageComponent,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,7 +8,7 @@ import {
 } from "./types";
 import { useTheme } from "./hooks/useTheme";
 import { useClaudeStreaming } from "./hooks/useClaudeStreaming";
-import { SunIcon, MoonIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import { SunIcon, MoonIcon, StopIcon } from "@heroicons/react/24/outline";
 import {
   ChatMessageComponent,
   SystemMessageComponent,
@@ -316,7 +316,7 @@ function App() {
               onKeyDown={handleKeyDown}
               placeholder={
                 isLoading && currentRequestId
-                  ? "Processing... (Press ESC to abort)"
+                  ? "Processing... (Press ESC to stop)"
                   : "Type your message... (Shift+Enter for new line)"
               }
               rows={1}
@@ -328,11 +328,10 @@ function App() {
                 <button
                   type="button"
                   onClick={abortRequest}
-                  className="px-3 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg font-medium transition-all duration-200 shadow-sm hover:shadow-md text-sm flex items-center gap-1"
-                  title="Abort (ESC)"
+                  className="p-2 bg-red-100 hover:bg-red-200 dark:bg-red-900/20 dark:hover:bg-red-900/30 text-red-600 dark:text-red-400 rounded-lg transition-all duration-200 shadow-sm hover:shadow-md"
+                  title="Stop (ESC)"
                 >
-                  <XMarkIcon className="w-4 h-4" />
-                  Abort
+                  <StopIcon className="w-4 h-4" />
                 </button>
               )}
               <button

--- a/frontend/src/hooks/useClaudeStreaming.ts
+++ b/frontend/src/hooks/useClaudeStreaming.ts
@@ -7,6 +7,7 @@ import type {
   ToolResultMessage,
   StreamResponse,
   SDKMessage,
+  AbortMessage,
 } from "../types";
 
 interface StreamingContext {
@@ -348,7 +349,7 @@ export function useClaudeStreaming() {
           };
           context.addMessage(errorMessage);
         } else if (data.type === "aborted") {
-          const abortedMessage: SystemMessage = {
+          const abortedMessage: AbortMessage = {
             type: "system",
             subtype: "abort",
             message: "Operation was aborted by user",

--- a/frontend/src/hooks/useClaudeStreaming.ts
+++ b/frontend/src/hooks/useClaudeStreaming.ts
@@ -337,6 +337,15 @@ export function useClaudeStreaming() {
             timestamp: Date.now(),
           };
           context.addMessage(errorMessage);
+        } else if (data.type === "aborted") {
+          const abortedMessage: SystemMessage = {
+            type: "system",
+            subtype: "abort",
+            message: "Operation was aborted by user",
+            timestamp: Date.now(),
+          };
+          context.addMessage(abortedMessage);
+          context.setCurrentAssistantMessage(null);
         }
       } catch (parseError) {
         console.error("Failed to parse stream line:", parseError);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -19,11 +19,20 @@ export type ErrorMessage = {
   timestamp: number;
 };
 
+// Abort message for aborted operations
+export type AbortMessage = {
+  type: "system";
+  subtype: "abort";
+  message: string;
+  timestamp: number;
+};
+
 // System message extending SDK types with timestamp
 export type SystemMessage = (
   | SDKSystemMessage
   | SDKResultMessage
   | ErrorMessage
+  | AbortMessage
 ) & {
   timestamp: number;
 };

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -7,8 +7,9 @@ export interface StreamResponse {
 export interface ChatRequest {
   message: string;
   sessionId?: string;
+  requestId: string;
 }
 
 export interface AbortRequest {
-  sessionId: string;
+  requestId: string;
 }

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1,5 +1,5 @@
 export interface StreamResponse {
-  type: "claude_json" | "error" | "done";
+  type: "claude_json" | "error" | "done" | "aborted";
   data?: unknown; // SDKMessage object for claude_json type
   error?: string;
 }
@@ -7,4 +7,8 @@ export interface StreamResponse {
 export interface ChatRequest {
   message: string;
   sessionId?: string;
+}
+
+export interface AbortRequest {
+  sessionId: string;
 }


### PR DESCRIPTION
## Summary

Implements abort functionality allowing users to interrupt streaming responses from the backend when encountering errors or wanting to stop processing.

## Changes

### Backend
- ✨ Add `/api/abort/:sessionId` endpoint for request interruption
- 🔧 Manage AbortController instances per session using Map
- 🛠️ Handle abort signals and proper resource cleanup
- 📡 Support "aborted" response type in streaming

### Frontend  
- 🖱️ Add Abort button in UI during loading state
- ⌨️ Implement ESC key shortcut for abort (designed for future configurability)
- 📱 Handle aborted state in streaming response processing
- 🎨 Add responsive visual feedback and UI updates

### Shared Types
- 📝 Add "aborted" type to StreamResponse interface
- 🏗️ Define AbortRequest interface for API consistency

## User Experience

- **Visual Control**: Red abort button appears during processing
- **Keyboard Access**: ESC key provides quick abort (configurable in future)
- **Clear Feedback**: Immediate response and status indication
- **Clean State**: Proper session cleanup after abort

## Test Plan

- [x] All existing tests pass
- [x] Code passes lint, typecheck, and format checks
- [x] Manual testing: abort button functionality
- [x] Manual testing: ESC key shortcut
- [x] Manual testing: proper cleanup and state management

## Type of Change

- [x] ✨ `feature` - New feature (non-breaking change which adds functionality)
- [x] 🔧 `enhancement` - Enhancement to existing functionality

Closes #50

🤖 Generated with [Claude Code](https://claude.ai/code)