### PR TITLE
Fix demo permission dialogs and add visual feedback

### DIFF
--- a/frontend/src/components/DemoPage.tsx
+++ b/frontend/src/components/DemoPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 import { useTheme } from "../hooks/useTheme";
 import { useChatState } from "../hooks/chat/useChatState";
@@ -36,8 +36,12 @@ export function DemoPage() {
     generateRequestId,
   } = useChatState();
 
-  const { permissionDialog, closePermissionDialog, allowToolPermanent } =
-    usePermissions();
+  const {
+    permissionDialog,
+    closePermissionDialog,
+    allowToolPermanent,
+    showPermissionDialog,
+  } = usePermissions();
 
   // Demo automation
   const {
@@ -66,18 +70,29 @@ export function DemoPage() {
     startRequest,
     resetRequestState,
     generateRequestId,
+    showPermissionDialog,
   });
 
   // Demo state
   const demoWorkingDirectory = "/Users/demo/claude-code-webui";
+  const [autoClickButton, setAutoClickButton] = useState<
+    "allow" | "allowPermanent" | null
+  >(null);
 
-  // Auto-allow permissions for demo after 2 seconds
+  // Auto-allow permissions for demo after 2 seconds with visual effect
   useEffect(() => {
     if (permissionDialog && permissionDialog.isOpen) {
       const timer = setTimeout(() => {
-        const pattern = permissionDialog.pattern;
-        allowToolPermanent(pattern);
-        closePermissionDialog();
+        // Show button press effect first
+        setAutoClickButton("allowPermanent");
+
+        // Then perform the actual action after a short delay
+        setTimeout(() => {
+          const pattern = permissionDialog.pattern;
+          allowToolPermanent(pattern);
+          closePermissionDialog();
+          setAutoClickButton(null);
+        }, 300); // Delay to show the press effect
       }, 2000); // Auto-allow after 2 seconds for demo
 
       return () => clearTimeout(timer);
@@ -211,6 +226,7 @@ export function DemoPage() {
           onAllowPermanent={handlePermissionAllowPermanent}
           onDeny={handlePermissionDeny}
           onClose={closePermissionDialog}
+          autoClickButton={autoClickButton}
         />
       )}
     </div>

--- a/frontend/src/components/PermissionDialog.tsx
+++ b/frontend/src/components/PermissionDialog.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from "react";
 import {
   XMarkIcon,
   ExclamationTriangleIcon,
@@ -11,6 +12,7 @@ interface PermissionDialogProps {
   onAllowPermanent: () => void;
   onDeny: () => void;
   onClose: () => void;
+  autoClickButton?: "allow" | "allowPermanent" | null;
 }
 
 export function PermissionDialog({
@@ -21,11 +23,35 @@ export function PermissionDialog({
   onAllowPermanent,
   onDeny,
   onClose,
+  autoClickButton = null,
 }: PermissionDialogProps) {
+  const [activeButton, setActiveButton] = useState<string | null>(null);
+
+  // Handle auto-click effect
+  useEffect(() => {
+    if (autoClickButton) {
+      setActiveButton(autoClickButton);
+      // Remove effect after animation
+      const timer = setTimeout(() => {
+        setActiveButton(null);
+      }, 300);
+      return () => clearTimeout(timer);
+    }
+  }, [autoClickButton]);
+
   if (!isOpen) return null;
 
   const handleDeny = () => {
     onDeny();
+  };
+
+  const getButtonClasses = (buttonType: string, baseClasses: string) => {
+    const isActive = activeButton === buttonType;
+    return `${baseClasses} ${
+      isActive
+        ? "scale-95 !bg-opacity-80 ring-2 ring-blue-300 dark:ring-blue-500"
+        : ""
+    } transition-all duration-300`;
   };
 
   return (
@@ -67,19 +93,28 @@ export function PermissionDialog({
           <div className="space-y-3">
             <button
               onClick={onAllow}
-              className="w-full px-4 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-medium transition-colors shadow-sm hover:shadow-md"
+              className={getButtonClasses(
+                "allow",
+                "w-full px-4 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-medium shadow-sm hover:shadow-md",
+              )}
             >
               Yes
             </button>
             <button
               onClick={onAllowPermanent}
-              className="w-full px-4 py-3 bg-green-600 hover:bg-green-700 text-white rounded-lg font-medium transition-colors shadow-sm hover:shadow-md"
+              className={getButtonClasses(
+                "allowPermanent",
+                "w-full px-4 py-3 bg-green-600 hover:bg-green-700 text-white rounded-lg font-medium shadow-sm hover:shadow-md",
+              )}
             >
               Yes, and don't ask again for {toolName}
             </button>
             <button
               onClick={handleDeny}
-              className="w-full px-4 py-3 bg-slate-200 hover:bg-slate-300 dark:bg-slate-700 dark:hover:bg-slate-600 text-slate-800 dark:text-slate-200 rounded-lg font-medium transition-colors"
+              className={getButtonClasses(
+                "deny",
+                "w-full px-4 py-3 bg-slate-200 hover:bg-slate-300 dark:bg-slate-700 dark:hover:bg-slate-600 text-slate-800 dark:text-slate-200 rounded-lg font-medium",
+              )}
             >
               No
             </button>

--- a/frontend/src/hooks/useDemoAutomation.ts
+++ b/frontend/src/hooks/useDemoAutomation.ts
@@ -32,6 +32,11 @@ interface DemoAutomationOptions {
   startRequest?: () => void;
   resetRequestState?: () => void;
   generateRequestId?: () => string;
+  showPermissionDialog?: (
+    toolName: string,
+    pattern: string,
+    toolUseId: string,
+  ) => void;
 }
 
 const DEFAULT_TYPING_SPEED = 30; // characters per second
@@ -51,6 +56,7 @@ export function useDemoAutomation(
     startRequest: externalStartRequest,
     resetRequestState: externalResetRequestState,
     generateRequestId: externalGenerateRequestId,
+    showPermissionDialog: externalShowPermissionDialog,
   } = options;
 
   // State
@@ -88,8 +94,10 @@ export function useDemoAutomation(
   const finalResetRequestState = externalResetRequestState || resetRequestState;
   const finalGenerateRequestId = externalGenerateRequestId || generateRequestId;
 
-  // Permissions
-  const { showPermissionDialog } = usePermissions();
+  // Permissions - use external if provided, otherwise use internal
+  const permissionsHook = usePermissions();
+  const finalShowPermissionDialog =
+    externalShowPermissionDialog || permissionsHook.showPermissionDialog;
 
   // Get current scenario
   const scenario = scenarioToStream(scenarioKey);
@@ -146,7 +154,7 @@ export function useDemoAutomation(
           pattern: string;
           toolUseId: string;
         };
-        showPermissionDialog(
+        finalShowPermissionDialog(
           errorData.toolName,
           errorData.pattern,
           errorData.toolUseId,
@@ -243,7 +251,7 @@ export function useDemoAutomation(
       setHasReceivedInit,
       setCurrentAssistantMessage,
       updateLastMessage,
-      showPermissionDialog,
+      finalShowPermissionDialog,
       finalAddMessage,
     ],
   );


### PR DESCRIPTION
## Summary
- Fixes permission dialogs not appearing in demo scenarios (issue #65)
- Adds visual button press effects for auto-permission actions
- Improves demo user experience with realistic auto-click animations

## Changes Made

### Permission Dialog State Sharing
- Fixed state isolation between `DemoPage` and `useDemoAutomation` hooks
- Added `showPermissionDialog` parameter to `DemoAutomationOptions` interface  
- Pass permission functions from parent component to automation hook

### Visual Feedback Effects
- Added scale animation (95%) and blue ring highlight for auto-clicked buttons
- Implemented 300ms delay to show press effect before permission grant
- Enhanced `PermissionDialog` component with `autoClickButton` prop

### Technical Details
- Permission dialogs now properly trigger during `fileOperations` and `codeAnalysis` scenarios
- Auto-permission happens after 2 seconds with visual "Allow Permanent" button press
- State management ensures single source of truth for permission dialog state

## Test Plan
- [x] Permission dialogs appear in demo scenarios
- [x] Auto-permission triggers after 2 seconds  
- [x] Visual button press effect shows before permission grant
- [x] Demo completes successfully with permission flow

Fixes #65 permission dialog functionality

🤖 Generated with [Claude Code](https://claude.ai/code)