### PR TITLE
Fix IME composition Enter key triggering unintended message submission

### DIFF
--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from "react";
+import React, { useRef, useEffect, useState } from "react";
 import { StopIcon } from "@heroicons/react/24/solid";
 import { UI_CONSTANTS, KEYBOARD_SHORTCUTS } from "../../utils/constants";
 
@@ -20,6 +20,7 @@ export function ChatInput({
   onAbort,
 }: ChatInputProps) {
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const [isComposing, setIsComposing] = useState(false);
 
   // Focus input when not loading
   useEffect(() => {
@@ -48,10 +49,19 @@ export function ChatInput({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === KEYBOARD_SHORTCUTS.SUBMIT && !e.shiftKey) {
+    if (e.key === KEYBOARD_SHORTCUTS.SUBMIT && !e.shiftKey && !isComposing) {
       e.preventDefault();
       onSubmit();
     }
+  };
+
+  const handleCompositionStart = () => {
+    setIsComposing(true);
+  };
+
+  const handleCompositionEnd = () => {
+    // Add small delay to handle race condition between composition and keydown events
+    setTimeout(() => setIsComposing(false), 0);
   };
 
   return (
@@ -62,6 +72,8 @@ export function ChatInput({
           value={input}
           onChange={(e) => onInputChange(e.target.value)}
           onKeyDown={handleKeyDown}
+          onCompositionStart={handleCompositionStart}
+          onCompositionEnd={handleCompositionEnd}
           placeholder={
             isLoading && currentRequestId
               ? "Processing... (Press ESC to stop)"


### PR DESCRIPTION
## Summary

- Fix issue where Japanese IME Enter key triggers unintended message submission
- Add composition state tracking to prevent Enter key interference during IME character conversion
- Improve user experience for IME users (Japanese, Chinese, Korean, etc.)

## Changes

- Add `isComposing` state tracking using React's composition events
- Implement `handleCompositionStart` and `handleCompositionEnd` with race condition handling
- Update `handleKeyDown` to check `\!isComposing` before submitting messages
- Add `onCompositionStart` and `onCompositionEnd` props to textarea element

## Technical Details

### Race Condition Handling

The implementation uses `setTimeout(() => setIsComposing(false), 0)` in `handleCompositionEnd` to ensure the composition event always runs after the keydown event, preventing edge cases where event order varies across browsers.

### IME Support

This fix supports all Input Method Editors including:
- Japanese IME (reported issue)
- Chinese IME (Pinyin, Zhuyin, etc.)
- Korean IME (Hangul input)
- Other composition-based input methods

## Test Plan

1. **Japanese IME Testing**:
   - Switch to Japanese IME
   - Type Japanese characters in chat input
   - Press Enter to confirm character conversion
   - Verify message is NOT submitted during conversion
   - Press Enter again to submit the message

2. **Normal Input Testing**:
   - Verify regular Enter key still submits messages
   - Verify Shift+Enter still creates new lines
   - Verify no regression in existing functionality

3. **Edge Cases**:
   - Test rapid typing during composition
   - Test switching between IME and normal input
   - Test on different browsers (Chrome, Firefox, Safari)

## Type of Change

- [x] 🐛 `bug` - Bug fix (non-breaking change which fixes an issue)
- [x] ✨ `enhancement` - Enhancement (improves user experience for IME users)
- [ ] 💥 `breaking` - Breaking change
- [ ] 📚 `documentation` - Documentation update
- [ ] ⚡ `performance` - Performance improvement
- [ ] 🔨 `refactor` - Code refactoring
- [ ] 🧪 `test` - Adding or updating tests
- [ ] 🔧 `chore` - Maintenance, dependencies, tooling

## References

- Fixes #72
- [React Composition Events Documentation](https://react.dev/reference/react-dom/components/input#oncompositionstart)
- [Similar fix in Verba project](https://github.com/weaviate/Verba/pull/277)
- [MDN CompositionEvent](https://developer.mozilla.org/en-US/docs/Web/API/CompositionEvent)

🤖 Generated with [Claude Code](https://claude.ai/code)