### PR TITLE
Fix demo comparison workflow timing and URL extraction issues

### DIFF
--- a/.github/workflows/demo-comparison.yml
+++ b/.github/workflows/demo-comparison.yml
@@ -1,8 +1,10 @@
 name: Demo Comparison
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
     inputs:
       release_tag:
@@ -19,6 +21,8 @@ jobs:
   compare-demos:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Only run if the triggering workflow was successful
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Checkout code
@@ -43,19 +47,26 @@ jobs:
       - name: Determine release tag
         id: release-tag
         run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            RELEASE_TAG="${{ github.event.release.tag_name }}"
-          else
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            # Get the latest release tag from the completed workflow
+            RELEASE_TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName')
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             RELEASE_TAG="${{ github.event.inputs.release_tag }}"
+          else
+            echo "❌ Unsupported event type: ${{ github.event_name }}"
+            exit 1
           fi
           echo "release_tag=$RELEASE_TAG" >> $GITHUB_OUTPUT
           echo "🏷️ Using release tag: $RELEASE_TAG"
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Extract README video URL
         id: extract-readme
         run: |
           # Extract the demo video URL from README.md (should be only one)
-          README_URL=$(grep -o 'https://[^)]*\.webm' README.md | head -1)
+          # Look for lines containing 'webm' and extract user-attachments URL
+          README_URL=$(grep 'webm' README.md | grep -o 'https://github.com/user-attachments/assets/[a-f0-9-]*' | head -1)
 
           if [ -z "$README_URL" ]; then
             echo "⚠️ No video URL found in README.md"
@@ -179,7 +190,7 @@ jobs:
             - **Release**: ${releaseTag}
             - **Repository**: ${repositoryUrl}
             - **Comparison threshold**: ${{ github.event.inputs.threshold || '95' }}%
-            - **Detected**: ${{ github.event_name == 'release' && 'Automatically after release' || 'Manual workflow trigger' }}
+            - **Detected**: ${{ github.event_name == 'workflow_run' && 'Automatically after release workflow' || 'Manual workflow trigger' }}
 
             ---
 
@@ -223,7 +234,7 @@ jobs:
           echo "| Item | Value |" >> $GITHUB_STEP_SUMMARY
           echo "|------|-------|" >> $GITHUB_STEP_SUMMARY
           echo "| Release Tag | ${{ steps.release-tag.outputs.release_tag }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Trigger | ${{ github.event_name == 'release' && 'Automatic (release published)' || 'Manual workflow dispatch' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Trigger | ${{ github.event_name == 'workflow_run' && 'Automatic (after release workflow)' || 'Manual workflow dispatch' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| README Video | ${{ steps.extract-readme.outputs.readme_found == 'true' && '✅ Found' || '❌ Not found' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Release Video | ${{ steps.download-release.outputs.release_found == 'true' && '✅ Found' || '❌ Not found' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Comparison Result | ${{ steps.compare.outputs.comparison_result == 'changes_detected' && '🔄 Changes detected' || steps.compare.outputs.comparison_result == 'no_changes' && '✅ No changes' || 'ℹ️ Skipped' }} |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Fixes two critical issues with the demo comparison workflow that were preventing it from working correctly:

1. **URL extraction pattern mismatch** - README videos use GitHub user-attachments URLs without `.webm` extension
2. **Race condition** - Demo comparison was running before release artifacts were uploaded

## Changes

### 1. Fixed URL Extraction Pattern
- **Problem**: Regex `https://[^)]*\.webm` expected URLs ending with `.webm`
- **Reality**: GitHub user-attachments URLs like `https://github.com/user-attachments/assets/559a46ae-41b9-440d-af3a-70ffe8e177fe`
- **Solution**: Updated to `grep 'webm' README.md | grep -o 'https://github.com/user-attachments/assets/[a-f0-9-]*'`

### 2. Fixed Workflow Execution Timing
- **Problem**: `release.published` triggered demo comparison immediately, before video upload completed
- **Solution**: Changed to `workflow_run` trigger that waits for Release workflow completion
- **Benefits**: 
  - Guarantees release artifacts are available before comparison
  - Prevents race conditions
  - Maintains proper execution order

### 3. Updated Release Tag Detection
- **workflow_run context**: Uses GitHub API to get latest release tag
- **workflow_dispatch**: Maintains manual input functionality  
- **Error handling**: Proper validation for unsupported event types

### 4. Enhanced Robustness
- Added success condition check for triggering workflow
- Updated all messaging and summaries for new workflow pattern
- Improved error handling and logging

## Type of Change

- [x] 🐛 `bug` - Bug fix (workflow execution issues)
- [x] 🔧 `chore` - Workflow/automation improvements

## Root Cause Analysis

**Timing Issue Flow**:
1. `tagpr.yml` creates tag on main branch push
2. `release.yml` triggers on tag push → builds artifacts → publishes release
3. `demo-comparison.yml` triggered on `release.published` → **race condition**
4. Demo comparison runs before video upload completes → fails to find videos

**New Flow**:
1. `tagpr.yml` creates tag on main branch push  
2. `release.yml` triggers on tag push → builds artifacts → publishes release → **completes**
3. `demo-comparison.yml` triggers on Release workflow completion → **guaranteed artifacts available**

## Test Plan

- [x] YAML syntax validation passes
- [x] Pre-commit hooks pass
- [x] Workflow logic updated for new trigger pattern
- [ ] Next release will test the complete fixed workflow

## Before/After

**Before**:
```yaml
on:
  release:
    types: [published]  # ❌ Race condition
```
```bash
README_URL=$(grep -o 'https://[^)]*\.webm' README.md)  # ❌ Wrong pattern
```

**After**:
```yaml
on:
  workflow_run:
    workflows: ["Release"]
    types: [completed]  # ✅ Waits for completion
    branches: [main]
```
```bash
README_URL=$(grep 'webm' README.md | grep -o 'https://github.com/user-attachments/assets/[a-f0-9-]*')  # ✅ Correct pattern
```

🤖 Generated with [Claude Code](https://claude.ai/code)