### PR TITLE
Implement flexible API port configuration (fixes #78)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Server Configuration
+# Port for the backend server (default: 8080)
+# This port is used by both backend and frontend development servers
+PORT=8080
+
+# Usage Examples:
+# 1. Create .env file with custom port:
+#    PORT=9000
+#
+# 2. Use environment variable directly:
+#    PORT=9000 npm run dev  (for frontend)
+#    PORT=9000 deno task dev  (for backend)
+#
+# Both frontend (via Vite proxy) and backend will use the same PORT value
+# Note: This project primarily uses .env file only for simplicity

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ This project consists of three main components:
 ### Backend (Deno)
 
 - **Location**: `backend/`
-- **Port**: 8080 (configurable via CLI)
+- **Port**: 8080 (configurable via CLI argument or PORT environment variable)
 - **Technology**: Deno with TypeScript + Hono framework
 - **Purpose**: Executes `claude` commands and streams JSON responses to frontend
 
@@ -72,7 +72,7 @@ This project consists of three main components:
 ### Frontend (React)
 
 - **Location**: `frontend/`
-- **Port**: 3000
+- **Port**: 3000 (configurable via `--port` CLI argument to `npm run dev`)
 - **Technology**: Vite + React + SWC + TypeScript + TailwindCSS + React Router
 - **Purpose**: Provides project selection and chat interface with streaming responses
 
@@ -164,6 +164,32 @@ The application supports conversation continuity within the same chat session us
 - Node.js (for frontend)
 - Claude CLI tool installed and configured
 
+### Port Configuration
+
+The application supports flexible port configuration for development:
+
+#### Unified Backend Port Management
+
+Create a `.env` file in the project root to set the backend port:
+
+```bash
+# .env
+PORT=9000
+```
+
+Both backend startup and frontend proxy configuration will automatically use this port:
+
+```bash
+cd backend && deno task dev     # Starts backend on port 9000
+cd frontend && npm run dev      # Configures proxy to localhost:9000
+```
+
+#### Alternative Configuration Methods
+
+- **Environment Variable**: `PORT=9000 deno task dev`
+- **CLI Argument**: `deno run --env-file --allow-net --allow-run --allow-read --allow-env main.ts --port 9000`
+- **Frontend Port**: `npm run dev -- --port 4000` (for frontend UI port)
+
 ### Running the Application
 
 1. **Start Backend**:
@@ -181,8 +207,8 @@ The application supports conversation continuity within the same chat session us
    ```
 
 3. **Access Application**:
-   - Frontend: http://localhost:3000
-   - Backend API: http://localhost:8080
+   - Frontend: http://localhost:3000 (or custom port via `npm run dev -- --port XXXX`)
+   - Backend API: http://localhost:8080 (or PORT from .env file)
 
 ### Project Structure
 
@@ -238,7 +264,7 @@ The application supports conversation continuity within the same chat session us
 
 1. **Raw JSON Streaming**: Backend passes Claude JSON responses without modification to allow frontend flexibility in handling different message types.
 
-2. **Separate Ports**: Backend (8080) and frontend (3000) run on different ports to allow independent development and deployment.
+2. **Configurable Ports**: Backend port configurable via PORT environment variable or CLI argument, frontend port via CLI argument to allow independent development and deployment.
 
 3. **TypeScript Throughout**: Consistent TypeScript usage across all components with shared type definitions.
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ chmod +x claude-code-webui-macos-arm64
 
 ### Development Setup
 
+#### Quick Start
+
 1. **Start Backend**:
 
    ```bash
@@ -77,6 +79,24 @@ chmod +x claude-code-webui-macos-arm64
 3. **Access Application**: http://localhost:3000
    - First, select a project directory from the list or choose a new one
    - Then interact with Claude in the context of that project
+
+#### Port Configuration
+
+You can customize the backend port using a `.env` file in the project root:
+
+```bash
+# Create .env file for custom port
+echo "PORT=9000" > .env
+
+# Both backend and frontend will use the same port
+cd backend && deno task dev     # Starts on port 9000
+cd frontend && npm run dev      # Proxies to localhost:9000
+```
+
+**Alternative methods:**
+- Environment variable: `PORT=9000 deno task dev` (backend)
+- CLI argument: `./claude-code-webui --port 9000` (binary)
+- Frontend port: `npm run dev -- --port 4000` (if needed)
 
 ## Documentation
 

--- a/backend/args.ts
+++ b/backend/args.ts
@@ -18,7 +18,7 @@ export function parseCliArgs(): ParsedArgs {
       "debug": "d",
     },
     default: {
-      port: "8080",
+      port: Deno.env.get("PORT") || "8080", // Use PORT env var if available, fallback to CLI arg or default
     },
   });
 

--- a/backend/deno.json
+++ b/backend/deno.json
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "dev": "deno run --allow-net --allow-run --allow-read --allow-env --watch main.ts --debug",
+    "dev": "deno run --env-file --allow-net --allow-run --allow-read --allow-env --watch main.ts --debug",
     "build": "deno compile --allow-net --allow-run --allow-read --allow-env --include ./VERSION --include ./dist --output ../dist/claude-code-webui main.ts",
     "format": "deno fmt",
     "lint": "deno lint",

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -1,6 +1,6 @@
 // API configuration
 export const API_CONFIG = {
-  BASE_URL: "http://localhost:8080",
+  BASE_URL: "", // Use relative paths for API calls
   ENDPOINTS: {
     CHAT: "/api/chat",
     ABORT: "/api/abort",

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -1,6 +1,5 @@
-// API configuration
+// API configuration - uses relative paths with Vite proxy in development
 export const API_CONFIG = {
-  BASE_URL: "", // Use relative paths for API calls
   ENDPOINTS: {
     CHAT: "/api/chat",
     ABORT: "/api/abort",
@@ -10,20 +9,20 @@ export const API_CONFIG = {
 
 // Helper function to get full API URL
 export const getApiUrl = (endpoint: string) => {
-  return `${API_CONFIG.BASE_URL}${endpoint}`;
+  return endpoint;
 };
 
 // Helper function to get abort URL
 export const getAbortUrl = (requestId: string) => {
-  return `${API_CONFIG.BASE_URL}${API_CONFIG.ENDPOINTS.ABORT}/${requestId}`;
+  return `${API_CONFIG.ENDPOINTS.ABORT}/${requestId}`;
 };
 
 // Helper function to get chat URL
 export const getChatUrl = () => {
-  return `${API_CONFIG.BASE_URL}${API_CONFIG.ENDPOINTS.CHAT}`;
+  return API_CONFIG.ENDPOINTS.CHAT;
 };
 
 // Helper function to get projects URL
 export const getProjectsUrl = () => {
-  return `${API_CONFIG.BASE_URL}${API_CONFIG.ENDPOINTS.PROJECTS}`;
+  return API_CONFIG.ENDPOINTS.PROJECTS;
 };

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import tailwindcss from "@tailwindcss/vite";
 import { dirname, resolve } from "path";
@@ -8,28 +8,40 @@ import { fileURLToPath } from "url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react(), tailwindcss()],
-  resolve: {
-    alias: {
-      "@shared": resolve(__dirname, "../shared"),
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, resolve(__dirname, ".."), "");
+  const apiPort = env.PORT || "8080";
+
+  return {
+    plugins: [react(), tailwindcss()],
+    resolve: {
+      alias: {
+        "@shared": resolve(__dirname, "../shared"),
+      },
     },
-  },
-  server: {
-    port: 3000,
-  },
-  test: {
-    environment: "jsdom",
-    setupFiles: ["./src/test-setup.ts"],
-    globals: true,
-    exclude: [
-      "**/node_modules/**",
-      "**/dist/**",
-      "**/cypress/**",
-      "**/.{idea,git,cache,output,temp}/**",
-      "**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*",
-      "**/scripts/**", // Exclude Playwright demo recording files
-      "**/tests/**", // Exclude Playwright validation tests
-    ],
-  },
+    server: {
+      port: 3000,
+      proxy: {
+        "/api": {
+          target: `http://localhost:${apiPort}`,
+          changeOrigin: true,
+          secure: false,
+        },
+      },
+    },
+    test: {
+      environment: "jsdom",
+      setupFiles: ["./src/test-setup.ts"],
+      globals: true,
+      exclude: [
+        "**/node_modules/**",
+        "**/dist/**",
+        "**/cypress/**",
+        "**/.{idea,git,cache,output,temp}/**",
+        "**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*",
+        "**/scripts/**", // Exclude Playwright demo recording files
+        "**/tests/**", // Exclude Playwright validation tests
+      ],
+    },
+  };
 });


### PR DESCRIPTION
## Summary
Implements flexible port configuration to resolve the hardcoded API port issue raised in #78.

### Key Changes

#### 🔧 Backend Configuration
- Add `--env-file` flag to `deno.json` for automatic `.env` file loading
- Update `args.ts` to prioritize `PORT` environment variable over CLI arguments
- Maintain backward compatibility with existing `--port` CLI option

#### ⚙️ Frontend Configuration  
- Replace hardcoded API URL with relative paths (`/api/*`)
- Add Vite proxy configuration that reads `PORT` from project root `.env`
- Use `loadEnv` to read environment variables from parent directory

#### 📋 Unified Configuration
- Single `PORT` environment variable controls both backend and frontend proxy
- Create `.env.example` with simple `PORT=8080` configuration
- Remove unnecessary `dev:port` script from package.json

#### 📚 Documentation Updates
- Add port configuration section to README.md with `.env` usage examples
- Update CLAUDE.md architecture and development sections  
- Document all configuration methods (env var, CLI, .env file)

### Benefits
- **Simplified Setup**: One environment variable (`PORT`) for both services
- **Developer Friendly**: Create `.env` file with custom port, both services sync automatically
- **Flexible**: Multiple configuration methods (env var, CLI args, .env file)
- **Backward Compatible**: Existing CLI arguments continue to work

### Usage Examples
```bash
# Create .env file for custom port
echo "PORT=9000" > .env

# Both services use the same port automatically
cd backend && deno task dev     # Starts on port 9000
cd frontend && npm run dev      # Proxies to localhost:9000
```

## Test plan
- [x] Verify backend starts with PORT environment variable
- [x] Verify frontend proxy routes to correct backend port
- [x] Confirm backward compatibility with CLI arguments
- [x] Test quality checks pass (lint, typecheck, tests)
- [x] Validate documentation accuracy

Resolves #78

🤖 Generated with [Claude Code](https://claude.ai/code)