### PR TITLE
Fix SPA routing fallback for direct URL access in binary mode

### DIFF
--- a/backend/main.ts
+++ b/backend/main.ts
@@ -231,31 +231,20 @@ app.post("/api/chat", async (c) => {
 });
 
 // Static file serving with SPA fallback
-// 1. Serve assets from /assets/* path
+// Serve static assets (CSS, JS, images, etc.)
 app.use("/assets/*", serveStatic({ root: import.meta.dirname + "/dist" }));
 
-// 2. Serve root level static files (favicon, etc.)
-app.get("/*", async (c) => {
-  const path = c.req.path;
+// Serve root-level static files (favicon, etc.) with SPA fallback
+app.use("/*", serveStatic({ root: import.meta.dirname + "/dist" }));
 
-  // Skip API routes (already handled above)
-  if (path.startsWith("/api/")) {
+// SPA fallback for all unmatched routes (but not API routes)
+app.get("*", async (c) => {
+  // Skip API routes
+  if (c.req.path.startsWith("/api/")) {
     return c.notFound();
   }
 
-  // For root level files with extensions, try to serve them from dist
-  if (path !== "/" && path.includes(".")) {
-    try {
-      const response = await serveStatic({
-        root: import.meta.dirname + "/dist",
-      })(c, () => Promise.resolve());
-      if (response) return response;
-    } catch {
-      // File not found, fall through to SPA fallback
-    }
-  }
-
-  // SPA fallback: serve index.html for all other routes
+  // Serve index.html for client-side routing
   try {
     const indexPath = import.meta.dirname + "/dist/index.html";
     const indexContent = await Deno.readTextFile(indexPath);


### PR DESCRIPTION
## Type of Change
- [x] 🐛 `bug` - Bug fix (non-breaking change which fixes an issue)
- [x] 🔨 `refactor` - Code refactoring
- [ ] ✨ `feature` - New feature (non-breaking change which adds functionality)
- [ ] 💥 `breaking` - Breaking change
- [ ] 📚 `documentation` - Documentation update
- [ ] ⚡ `performance` - Performance improvement
- [ ] 🧪 `test` - Adding or updating tests
- [ ] 🔧 `chore` - Maintenance, dependencies, tooling

## Summary
- Fixes issue where direct URL access to `/projects/...` returns 404 in binary mode
- Refactors SPA fallback routing to use Hono's standard patterns with cleaner, more maintainable code

## Changes
- **Simplified Implementation**: Replaced complex conditional logic with standard Hono routing patterns
- **Static Asset Handling**: Uses `serveStatic` middleware for `/assets/*` and general static files
- **SPA Fallback**: Implements clean catch-all route with `app.get("*")` for client-side routing
- **Code Reduction**: Reduced implementation by ~15 lines while maintaining same functionality

## Technical Details
The new implementation follows Hono's recommended patterns:
1. **Static Assets**: `/assets/*` served via dedicated `serveStatic` middleware
2. **General Static Files**: Root-level files served via general `serveStatic` middleware  
3. **SPA Fallback**: Simple `app.get("*")` catch-all route serves `index.html`
4. **API Protection**: API routes are explicitly skipped in the fallback handler

**Before (Complex)**:
- Manual file existence checking with try-catch
- Complex conditional logic for different path types
- Custom file reading and response handling

**After (Standard)**:
- Uses Hono's built-in `serveStatic` middleware
- Simple catch-all route for SPA fallback
- Follows framework conventions

## Test plan
- [x] Direct URL access to project pages works in binary mode
- [x] Static assets are served correctly (CSS, JS, images)
- [x] API endpoints continue to function normally
- [x] Root-level files (favicon, etc.) are served properly
- [x] Quality checks pass (formatting, linting, type checking, tests)
- [x] Code is more readable and maintainable

🤖 Generated with [Claude Code](https://claude.ai/code)