### PR TITLE
🔧 Remove unnecessary apt-get update in demo-comparison workflow

### DIFF
--- a/.github/workflows/demo-comparison.yml
+++ b/.github/workflows/demo-comparison.yml
@@ -40,7 +40,6 @@ jobs:
 
       - name: Install FFmpeg for video comparison
         run: |
-          sudo apt-get update
           sudo apt-get install -y ffmpeg
 
       - name: Determine release tag


### PR DESCRIPTION
## Summary
- Remove unnecessary `apt-get update` command from demo-comparison workflow
- The command was only used to install FFmpeg, which is typically available on GitHub's ubuntu-latest runners

## Type of Change
- [x] 🔧 `chore` - Maintenance, dependencies, tooling

## Benefits
- **Performance**: Faster workflow execution by avoiding package index downloads
- **Simplicity**: Cleaner, more focused installation step
- **Efficiency**: GitHub runners typically have FFmpeg available or can install it directly

## Technical Details
The `apt-get update` command downloads the entire package index, which is unnecessary for installing a single widely-available package like FFmpeg. Most GitHub ubuntu-latest runners either have FFmpeg pre-installed or can install it efficiently without updating the package cache.

## Test Plan
- [ ] Manual workflow_dispatch test with existing release tag
- [ ] Verify FFmpeg installation succeeds
- [ ] Confirm video comparison functionality works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)