### PR TITLE
fix: update release workflow to resolve build failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
         with:
           deno-version: v2.x
 
-      - name: Install dependencies
-        run: cd backend && deno install
+      - name: Cache dependencies
+        run: cd backend && deno cache cli/deno.ts
 
       - name: Format check
         run: cd backend && deno fmt --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
         with:
           deno-version: v2.x
 
-      - name: Cache dependencies
-        run: cd backend && deno cache cli/deno.ts
+      - name: Install and cache dependencies
+        run: cd backend && deno install && deno cache cli/deno.ts
 
       - name: Format check
         run: cd backend && deno fmt --check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,10 @@ jobs:
         with:
           deno-version: v2.x
 
+      - name: Install Deno dependencies
+        run: deno install
+        working-directory: backend
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -54,7 +58,7 @@ jobs:
           cp -r frontend/dist backend/dist
 
       - name: Build backend binary
-        run: deno compile --allow-net --allow-run --allow-read --allow-env --include ./VERSION --include ./dist --target ${{ matrix.target }} --output ../dist/${{ matrix.artifact_name }} main.ts
+        run: deno compile --allow-net --allow-run --allow-read --allow-env --include ./VERSION --include ./dist --target ${{ matrix.target }} --output ../dist/${{ matrix.artifact_name }} cli/deno.ts
         working-directory: backend
 
       - name: Upload artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,8 @@ jobs:
         with:
           deno-version: v2.x
 
-      - name: Install Deno dependencies
-        run: deno install
+      - name: Cache Deno dependencies
+        run: deno cache cli/deno.ts
         working-directory: backend
 
       - name: Setup Node.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,8 @@ jobs:
         with:
           deno-version: v2.x
 
-      - name: Cache Deno dependencies
-        run: deno cache cli/deno.ts
+      - name: Install and cache Deno dependencies
+        run: deno install && deno cache cli/deno.ts
         working-directory: backend
 
       - name: Setup Node.js


### PR DESCRIPTION
## Type of Change

- [x] 🐛 `bug` - Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ `feature` - New feature (non-breaking change which adds functionality)
- [ ] 💥 `breaking` - Breaking change
- [ ] 📚 `documentation` - Documentation update
- [ ] ⚡ `performance` - Performance improvement
- [ ] 🔨 `refactor` - Code refactoring
- [ ] 🧪 `test` - Adding or updating tests
- [x] 🔧 `chore` - Maintenance, dependencies, tooling
- [x] 🖥️ `backend` - Backend-related changes
- [ ] 🎨 `frontend` - Frontend-related changes

## Summary

Fixes the "Build backend binary" failures in the release workflow by updating it to match the current backend structure and dependencies.

### Root Cause
The release workflow was using outdated configurations:
1. **Wrong entry point**: Trying to compile `main.ts` which no longer exists
2. **Missing dependencies**: No `deno install` step to install required dependencies

### Solution
- **Update entry point**: Change from `main.ts` to `cli/deno.ts` to match current backend structure
- **Add dependency installation**: Include `deno install` step before building, consistent with CI workflow
- **Maintain cross-platform support**: Keep existing matrix strategy for Linux/macOS x64/ARM64 builds

### Technical Changes
- Updated compile command in release.yml to use `cli/deno.ts` as entry point
- Added `deno install` step after Deno setup to ensure dependencies are available
- Follows the same pattern as the working CI workflow

## Test Plan
- [x] Verified current backend structure uses `cli/deno.ts` as main entry point
- [x] Confirmed `deno install` step is required (present in CI workflow)
- [x] Local build test: `cd backend && deno task build` works correctly
- [x] All quality checks passing (format, lint, typecheck, tests, build)

### Next Release Verification
The next version release will validate that binary builds work correctly across all platforms:
- Linux x64/ARM64
- macOS x64/ARM64

🤖 Generated with [Claude Code](https://claude.ai/code)