### PR TITLE
Add Node.js CLI entry point and runtime support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,7 @@ The application supports conversation continuity within the same chat session us
 - Deno (for backend)
 - Node.js (for frontend)
 - Claude CLI tool installed and configured
+- dotenvx (for .env file processing): `npm install -g @dotenvx/dotenvx`
 
 ### Port Configuration
 
@@ -206,15 +207,16 @@ PORT=9000
 Both backend startup and frontend proxy configuration will automatically use this port:
 
 ```bash
-cd backend && deno task dev     # Starts backend on port 9000
+cd backend && deno task dev     # Uses dotenvx to read ../.env and starts backend on port 9000
 cd frontend && npm run dev      # Configures proxy to localhost:9000
 ```
 
 #### Alternative Configuration Methods
 
 - **Environment Variable**: `PORT=9000 deno task dev`
-- **CLI Argument**: `deno run --env-file --allow-net --allow-run --allow-read --allow-env cli/deno.ts --port 9000`
+- **CLI Argument**: `dotenvx run --env-file=../.env -- deno run --allow-net --allow-run --allow-read --allow-env cli/deno.ts --port 9000`
 - **Frontend Port**: `npm run dev -- --port 4000` (for frontend UI port)
+- **Node.js Backend**: `cd backend && npm run dev` (uses dotenvx to read ../.env)
 
 ### Running the Application
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ cd frontend && npm run dev
 
 - ✅ **Claude CLI** installed and authenticated ([Get it here](https://github.com/anthropics/claude-code))
 - ✅ **Modern browser** (Chrome, Firefox, Safari, Edge)
+- ✅ **dotenvx** (for development): [Install guide](https://dotenvx.com/docs/install)
 
 
 ---
@@ -123,6 +124,8 @@ PORT=9000 DEBUG=true ./claude-code-webui
 git clone https://github.com/sugyan/claude-code-webui.git
 cd claude-code-webui
 
+# Install dotenvx (see prerequisites)
+
 # Start backend (choose one)
 cd backend
 deno task dev    # Deno runtime
@@ -142,7 +145,9 @@ Create `.env` file in project root:
 echo "PORT=9000" > .env
 ```
 
-Both backend and frontend will automatically use this port.
+Both backend and frontend will automatically use this port:
+- Backend: Uses dotenvx to read the `.env` file
+- Frontend: Uses Vite's built-in `.env` support
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ chmod +x claude-code-webui-macos-arm64
 ### Option 2: Development Mode
 
 ```bash
-# Backend
-cd backend && deno task dev
+# Backend (choose one)
+cd backend && deno task dev    # Deno runtime
+cd backend && npm run dev      # Node.js runtime
 
 # Frontend (new terminal)
 cd frontend && npm run dev
@@ -122,9 +123,11 @@ PORT=9000 DEBUG=true ./claude-code-webui
 git clone https://github.com/sugyan/claude-code-webui.git
 cd claude-code-webui
 
-# Start backend
+# Start backend (choose one)
 cd backend
-deno task dev
+deno task dev    # Deno runtime
+# OR
+npm run dev      # Node.js runtime
 
 # Start frontend (new terminal)
 cd frontend

--- a/backend/cli/args.ts
+++ b/backend/cli/args.ts
@@ -17,9 +17,24 @@ export async function parseCliArgs(runtime: Runtime): Promise<ParsedArgs> {
   // Read version from VERSION file
   let version = "unknown";
   try {
-    const versionContent = await runtime.readTextFile(
-      new URL("../VERSION", import.meta.url).pathname,
-    );
+    // Cross-platform path resolution for VERSION file
+    let versionPath: string;
+    if (
+      typeof globalThis.process !== "undefined" &&
+      globalThis.process.versions?.node
+    ) {
+      // Node.js environment
+      const { fileURLToPath } = await import("node:url");
+      const { dirname, join } = await import("node:path");
+      const __filename = fileURLToPath(import.meta.url);
+      const __dirname = dirname(__filename);
+      versionPath = join(__dirname, "../VERSION");
+    } else {
+      // Deno environment
+      versionPath = new URL("../VERSION", import.meta.url).pathname;
+    }
+
+    const versionContent = await runtime.readTextFile(versionPath);
     version = versionContent.trim();
   } catch (error) {
     console.error(

--- a/backend/cli/node.ts
+++ b/backend/cli/node.ts
@@ -15,9 +15,7 @@ import { dirname, join } from "node:path";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-async function main() {
-  // Initialize Node.js runtime
-  const runtime = new NodeRuntime();
+async function main(runtime: NodeRuntime) {
 
   // Parse CLI arguments
   const args = await parseCliArgs(runtime);
@@ -60,7 +58,7 @@ async function validateClaudeCli(runtime: NodeRuntime) {
 
 // Run the application
 const runtime = new NodeRuntime();
-main().catch((error) => {
+main(runtime).catch((error) => {
   console.error("Failed to start server:", error);
   runtime.exit(1);
 });

--- a/backend/cli/node.ts
+++ b/backend/cli/node.ts
@@ -1,17 +1,23 @@
 /**
- * Deno-specific entry point
+ * Node.js-specific entry point
  *
- * This module handles Deno-specific initialization including CLI argument parsing,
- * Claude CLI validation, and server startup using the DenoRuntime.
+ * This module handles Node.js-specific initialization including CLI argument parsing,
+ * Claude CLI validation, and server startup using the NodeRuntime.
  */
 
-import { createApp } from "../app.ts";
-import { DenoRuntime } from "../runtime/deno.ts";
-import { parseCliArgs } from "./args.ts";
+import { createApp } from "../app.js";
+import { NodeRuntime } from "../runtime/node.js";
+import { parseCliArgs } from "./args.js";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+// Get directory path for this file
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 async function main() {
-  // Initialize Deno runtime
-  const runtime = new DenoRuntime();
+  // Initialize Node.js runtime
+  const runtime = new NodeRuntime();
 
   // Parse CLI arguments
   const args = await parseCliArgs(runtime);
@@ -28,14 +34,14 @@ async function main() {
   // Create application
   const app = await createApp(runtime, {
     debugMode: args.debug,
-    distPath: new URL("../dist", import.meta.url).pathname,
+    distPath: join(__dirname, "../dist"),
   });
 
   // Start server
   runtime.serve(args.port, args.host, app.fetch);
 }
 
-async function validateClaudeCli(runtime: DenoRuntime) {
+async function validateClaudeCli(runtime: NodeRuntime) {
   try {
     const result = await runtime.runCommand("claude", ["--version"]);
 
@@ -53,10 +59,8 @@ async function validateClaudeCli(runtime: DenoRuntime) {
 }
 
 // Run the application
-if (import.meta.main) {
-  const runtime = new DenoRuntime();
-  main().catch((error) => {
-    console.error("Failed to start server:", error);
-    runtime.exit(1);
-  });
-}
+const runtime = new NodeRuntime();
+main().catch((error) => {
+  console.error("Failed to start server:", error);
+  runtime.exit(1);
+});

--- a/backend/deno.json
+++ b/backend/deno.json
@@ -1,6 +1,11 @@
 {
+  "compilerOptions": {
+    "lib": ["deno.ns", "deno.window"],
+    "strict": true
+  },
   "exclude": [
     "runtime/node.ts",
+    "cli/node.ts",
     "tests/node/"
   ],
   "tasks": {

--- a/backend/deno.json
+++ b/backend/deno.json
@@ -9,7 +9,7 @@
     "tests/node/"
   ],
   "tasks": {
-    "dev": "deno run --env-file --allow-net --allow-run --allow-read --allow-env --watch cli/deno.ts --debug",
+    "dev": "dotenvx run --env-file=../.env -- deno run --allow-net --allow-run --allow-read --allow-env --watch cli/deno.ts --debug",
     "build": "deno compile --allow-net --allow-run --allow-read --allow-env --include ./VERSION --include ./dist --output ../dist/claude-code-webui cli/deno.ts",
     "format": "deno fmt",
     "lint": "deno lint",

--- a/backend/deno.lock
+++ b/backend/deno.lock
@@ -1320,6 +1320,7 @@
         "npm:@anthropic-ai/claude-code@1.0.33",
         "npm:@hono/node-server@1",
         "npm:@types/node@20",
+        "npm:commander@14",
         "npm:eslint@9",
         "npm:hono@4",
         "npm:tsx@4",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@anthropic-ai/claude-code": "1.0.33",
         "@hono/node-server": "^1.0.0",
+        "commander": "^14.0.0",
         "hono": "^4.0.0"
       },
       "devDependencies": {
@@ -1526,6 +1527,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
+      "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "dist/cli/node.js",
   "scripts": {
-    "dev": "tsx watch cli/node.ts --debug",
+    "dev": "dotenvx run --env-file=../.env -- tsx watch cli/node.ts --debug",
     "build": "echo 'Node.js backend uses tsx for runtime compilation - no build step needed'",
     "start": "node dist/cli/node.js",
     "test": "vitest",

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
   "main": "dist/cli/node.js",
   "scripts": {
     "dev": "tsx watch cli/node.ts --debug",
-    "build": "tsc",
+    "build": "echo 'Node.js backend uses tsx for runtime compilation - no build step needed'",
     "start": "node dist/cli/node.js",
     "test": "vitest",
     "lint": "eslint **/*.ts --ignore-pattern dist/",
@@ -14,15 +14,16 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-code": "1.0.33",
-    "hono": "^4.0.0",
-    "@hono/node-server": "^1.0.0"
+    "@hono/node-server": "^1.0.0",
+    "commander": "^14.0.0",
+    "hono": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "typescript": "^5.0.0",
+    "eslint": "^9.0.0",
     "tsx": "^4.0.0",
-    "vitest": "^2.0.0",
-    "eslint": "^9.0.0"
+    "typescript": "^5.0.0",
+    "vitest": "^2.0.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,38 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "allowSyntheticDefaultImports": true,
+    "types": ["node", "vitest/globals"],
+    "lib": ["ES2022", "DOM"],
+    "noEmit": true
+  },
+  "include": [
+    "../shared/**/*.ts",
+    "cli/node.ts",
+    "runtime/node.ts",
+    "app.ts",
+    "cli/args.ts",
+    "handlers/**/*.ts",
+    "history/**/*.ts",
+    "middleware/**/*.ts",
+    "runtime/types.ts",
+    "types.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "deno.json",
+    "deno.lock",
+    "runtime/deno.ts",
+    "cli/deno.ts",
+    "pathUtils.test.ts"
+  ]
+}


### PR DESCRIPTION
## Type of Change

- [ ] 🐛 `bug` - Bug fix (non-breaking change which fixes an issue)
- [x] ✨ `feature` - New feature (non-breaking change which adds functionality)
- [ ] 💥 `breaking` - Breaking change
- [x] 📚 `documentation` - Documentation update
- [ ] ⚡ `performance` - Performance improvement
- [ ] 🔨 `refactor` - Code refactoring
- [ ] 🧪 `test` - Adding or updating tests
- [ ] 🔧 `chore` - Maintenance, dependencies, tooling
- [x] 🖥️ `backend` - Backend-related changes
- [ ] 🎨 `frontend` - Frontend-related changes

## Summary

This PR adds Node.js CLI entry point and runtime support to enable running the backend server with either Deno or Node.js.

- ✅ **Node.js CLI entry point** (`cli/node.ts`) with identical functionality to Deno version
- ✅ **Cross-platform path resolution** in CLI args module
- ✅ **TypeScript configuration** for Node.js type checking
- ✅ **Runtime-specific static file serving** in app.ts
- ✅ **Updated documentation** with Node.js development instructions
- ✅ **Commander dependency** for CLI argument parsing
- ✅ **tsx configuration** for runtime compilation (no build step needed)
- ✅ **Proper Deno/Node.js coexistence** via deno.json compilerOptions

## Key Changes

- **New Files:**
  - `backend/cli/node.ts` - Node.js CLI entry point
  - `backend/tsconfig.json` - TypeScript configuration for Node.js

- **Updated Files:**
  - `backend/app.ts` - Runtime-specific static file serving
  - `backend/cli/args.ts` - Cross-platform path resolution
  - `backend/cli/deno.ts` - Async createApp support
  - `backend/package.json` - Commander dependency
  - `backend/deno.json` - Deno-specific compiler options for coexistence
  - `README.md` - Node.js development documentation

## Test Plan

- [x] Node.js server starts successfully with `npm run dev`
- [x] All API endpoints work correctly
- [x] Claude CLI integration functions properly
- [x] Both Deno and Node.js development workflows work
- [x] All quality checks pass (format, lint, typecheck, tests)
- [x] Cross-platform path resolution works correctly

## Development Usage

```bash
# Backend options
cd backend && deno task dev    # Deno runtime
cd backend && npm run dev      # Node.js runtime

# Frontend (unchanged)
cd frontend && npm run dev
```

Resolves #127

🤖 Generated with [Claude Code](https://claude.ai/code)