### PR TITLE
fix: unify static file paths across Deno and Node.js builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,13 +52,16 @@ jobs:
         run: npm run build
         working-directory: frontend
 
-      - name: Copy frontend dist to backend
-        run: |
-          rm -rf backend/dist
-          cp -r frontend/dist backend/dist
+      - name: Copy frontend assets
+        run: node scripts/copy-frontend.js
+        working-directory: backend
+
+      - name: Generate version.ts
+        run: node scripts/generate-version.js
+        working-directory: backend
 
       - name: Build backend binary
-        run: deno compile --allow-net --allow-run --allow-read --allow-env --include ./VERSION --include ./dist --target ${{ matrix.target }} --output ../dist/${{ matrix.artifact_name }} cli/deno.ts
+        run: deno compile --allow-net --allow-run --allow-read --allow-env --include ./dist/static --target ${{ matrix.target }} --output ../dist/${{ matrix.artifact_name }} cli/deno.ts
         working-directory: backend
 
       - name: Upload artifact

--- a/backend/cli/deno.ts
+++ b/backend/cli/deno.ts
@@ -26,7 +26,7 @@ async function main(runtime: DenoRuntime) {
   // Create application
   const app = createApp(runtime, {
     debugMode: args.debug,
-    staticPath: new URL("../static", import.meta.url).pathname,
+    staticPath: new URL("../dist/static", import.meta.url).pathname,
   });
 
   // Start server

--- a/backend/deno.json
+++ b/backend/deno.json
@@ -11,7 +11,7 @@
   "tasks": {
     "generate-version": "node scripts/generate-version.js",
     "dev": "deno task generate-version && dotenvx run --env-file=../.env -- deno run --allow-net --allow-run --allow-read --allow-env --watch cli/deno.ts --debug",
-    "build": "deno task generate-version && deno compile --allow-net --allow-run --allow-read --allow-env --include ./dist --output ../dist/claude-code-webui cli/deno.ts",
+    "build": "deno task generate-version && deno compile --allow-net --allow-run --allow-read --allow-env --include ./dist/static --output ../dist/claude-code-webui cli/deno.ts",
     "format": "deno fmt",
     "lint": "deno lint",
     "check": "deno check",

--- a/backend/deno.lock
+++ b/backend/deno.lock
@@ -1317,7 +1317,7 @@
     ],
     "packageJson": {
       "dependencies": [
-        "npm:@anthropic-ai/claude-code@>=1.0.33",
+        "npm:@anthropic-ai/claude-code@^1.0.33",
         "npm:@hono/node-server@1",
         "npm:@types/node@20",
         "npm:commander@14",


### PR DESCRIPTION
## Type of Change

- [x] 🐛 `bug` - Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ `feature` - New feature (non-breaking change which adds functionality)
- [ ] 💥 `breaking` - Breaking change
- [ ] 📚 `documentation` - Documentation update
- [ ] ⚡ `performance` - Performance improvement
- [ ] 🔨 `refactor` - Code refactoring
- [ ] 🧪 `test` - Adding or updating tests
- [ ] 🔧 `chore` - Maintenance, dependencies, tooling
- [x] 🖥️ `backend` - Backend-related changes
- [ ] 🎨 `frontend` - Frontend-related changes

## Description

Unify static file paths between Deno binary distribution and npm package to ensure consistent asset serving across both distribution methods.

**Problem**: Deno binary used `../static` while npm package used `./dist/static`, causing inconsistent build processes and potential bundling of npm artifacts into Deno binary.

**Solution**: Standardize both distributions to use `backend/dist/static/` structure.

## Changes

- **Deno staticPath**: Update from `../static` to `../dist/static` for consistency with npm package
- **release.yml**: Replace direct `cp` command with `copy-frontend.js` script usage  
- **deno.json & release.yml**: Update `--include` flag from `./dist` to `./dist/static` to exclude npm package artifacts
- **Version handling**: Add `version.ts` generation step before Deno compilation
- **Cleanup**: Remove deprecated `--include ./VERSION` from deno compile command

## Technical Details

**Unified static file structure:**
- **Path**: `backend/dist/static/`
- **Assets**: `/assets/*` → CSS, JS files
- **Fallback**: Other routes → `index.html`

**Build improvements:**
- Prevents bundling npm package artifacts (`dist/cli/`) into Deno binary
- Uses consistent `copy-frontend.js` script in both npm build and release workflow
- Ensures static assets are correctly included in both local builds and GitHub releases

## Test Plan

- [x] All CI checks pass
- [x] Deno staticPath points to correct unified location  
- [x] Release workflow uses consistent asset copying method
- [x] Deno compile includes only static assets, not npm artifacts

Closes #150

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>