### PR TITLE
fix: update release workflow to trigger on tags without v prefix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      - "*"
 
 jobs:
   build:


### PR DESCRIPTION
## Type of Change

- [x] 🐛 `bug` - Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ `feature` - New feature (non-breaking change which adds functionality)
- [ ] 💥 `breaking` - Breaking change
- [ ] 📚 `documentation` - Documentation update
- [ ] ⚡ `performance` - Performance improvement
- [ ] 🔨 `refactor` - Code refactoring
- [ ] 🧪 `test` - Adding or updating tests
- [x] 🔧 `chore` - Maintenance, dependencies, tooling
- [x] 🖥️ `backend` - Backend-related changes
- [ ] 🎨 `frontend` - Frontend-related changes

## Summary

- 🐛 Fixed release workflow trigger pattern to work with tagpr configuration
- 🔧 Updated trigger from `"v*"` to `"*"` to match tags without v prefix

## Problem

The tagpr configuration has `vPrefix = false`, which creates tags like `0.1.29` instead of `v0.1.29`. However, the release workflow was still configured to trigger only on tags starting with "v", causing releases to not trigger automatically.

## Solution

Updated `.github/workflows/release.yml` to trigger on all tags (`"*"`) instead of just versioned tags (`"v*"`), matching the tagpr configuration.

## Test Plan

- [x] Verified tagpr config has `vPrefix = false`
- [x] Confirmed recent tags don't have v prefix (e.g., `v0.1.28` was the last v-prefixed tag)
- [x] Updated workflow trigger pattern
- [x] Quality checks pass