### PR TITLE
Release for 0.1.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.32](https://github.com/sugyan/claude-code-webui/compare/0.1.31...0.1.32) - 2025-07-11
+- fix: remove redundant version consistency check from npm publishing workflow by @sugyan in https://github.com/sugyan/claude-code-webui/pull/167
+
 ## [0.1.31](https://github.com/sugyan/claude-code-webui/compare/0.1.30...0.1.31) - 2025-07-11
 - docs: add --claude-path option to README by @sugyan in https://github.com/sugyan/claude-code-webui/pull/164
 - feat: add CI/CD npm publishing automation by @sugyan in https://github.com/sugyan/claude-code-webui/pull/166

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-webui",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "description": "Web-based interface for the Claude Code CLI with streaming chat interface",
   "keywords": [
     "claude",


### PR DESCRIPTION
This pull request is for the next release as 0.1.32 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag 0.1.32 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-0.1.31" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* fix: remove redundant version consistency check from npm publishing workflow by @sugyan in https://github.com/sugyan/claude-code-webui/pull/167


**Full Changelog**: https://github.com/sugyan/claude-code-webui/compare/0.1.31...0.1.32