### PR TITLE
fix: unify backend testing to use npm run test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Node.js (for version generation)
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "22"
+          cache: "npm"
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install backend dependencies
+        run: cd backend && npm ci
 
       - name: Generate version.ts
         run: cd backend && node scripts/generate-version.js
@@ -27,7 +32,7 @@ jobs:
         with:
           deno-version: v2.x
 
-      - name: Install and cache dependencies
+      - name: Install and cache Deno dependencies
         run: cd backend && deno install && deno cache cli/deno.ts
 
       - name: Format check
@@ -38,6 +43,9 @@ jobs:
 
       - name: Type check
         run: cd backend && deno check
+
+      - name: Test
+        run: cd backend && npm run test
 
   frontend:
     name: Frontend

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ test: test-frontend test-backend
 test-frontend:
 	cd frontend && npm run test:run
 test-backend:
-	cd backend && deno task test
+	cd backend && npm run test
 
 # Building
 build: build-frontend copy-dist build-backend

--- a/backend/package.json
+++ b/backend/package.json
@@ -45,7 +45,7 @@
     "build:bundle": "node scripts/build-bundle.js",
     "build:static": "node scripts/copy-frontend.js",
     "start": "node dist/cli/node.js",
-    "test": "vitest",
+    "test": "vitest --run --reporter=verbose",
     "lint": "eslint **/*.ts --ignore-pattern dist/",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "npm run build && npm run test"

--- a/backend/pathUtils.test.ts
+++ b/backend/pathUtils.test.ts
@@ -1,5 +1,5 @@
-import { assertEquals } from "https://deno.land/std@0.208.0/assert/mod.ts";
-import { getEncodedProjectName } from "./history/pathUtils.ts";
+import { describe, expect, it } from "vitest";
+import { getEncodedProjectName } from "./history/pathUtils.js";
 import type { Runtime } from "./runtime/types.ts";
 import type { MiddlewareHandler } from "hono";
 
@@ -49,43 +49,44 @@ const mockRuntime: Runtime = {
     Promise.resolve(new Response()),
 };
 
-Deno.test("pathUtils - getEncodedProjectName with dots and slashes", async () => {
-  // Test with a path that contains both dots and slashes
-  const testPath = "/Users/test/.example/github.com/project-name";
-  const result = await getEncodedProjectName(testPath, mockRuntime);
+describe("pathUtils", () => {
+  it("getEncodedProjectName with dots and slashes", async () => {
+    // Test with a path that contains both dots and slashes
+    const testPath = "/Users/test/.example/github.com/project-name";
+    const result = await getEncodedProjectName(testPath, mockRuntime);
 
-  const expectedEncoding = testPath.replace(/\/$/, "").replace(/[/.]/g, "-");
+    const expectedEncoding = testPath.replace(/\/$/, "").replace(/[/.]/g, "-");
 
-  // Should convert both '/' and '.' to '-'
-  assertEquals(
-    expectedEncoding,
-    "-Users-test--example-github-com-project-name",
-  );
+    // Should convert both '/' and '.' to '-'
+    expect(expectedEncoding).toBe(
+      "-Users-test--example-github-com-project-name",
+    );
 
-  // Note: result will be null since this test path doesn't exist in .claude/projects
-  // but the encoding logic is verified above
-  assertEquals(result, null);
-});
+    // Note: result will be null since this test path doesn't exist in .claude/projects
+    // but the encoding logic is verified above
+    expect(result).toBe(null);
+  });
 
-Deno.test("pathUtils - test projects API response", async () => {
-  // Import the projects handler
-  const { handleProjectsRequest } = await import("./handlers/projects.ts");
+  it("test projects API response", async () => {
+    // Import the projects handler
+    const { handleProjectsRequest } = await import("./handlers/projects.js");
 
-  // Create a mock Hono context with runtime
-  const mockContext = {
-    var: {
-      config: {
-        runtime: mockRuntime,
+    // Create a mock Hono context with runtime
+    const mockContext = {
+      var: {
+        config: {
+          runtime: mockRuntime,
+        },
       },
-    },
-    json: (data: unknown, status?: number) => {
-      // Debug logs removed to keep test output clean
-      // console.log("Mock API response:", JSON.stringify(data, null, 2));
-      // console.log("Response status:", status || 200);
-      return { data, status };
-    },
-  };
+      json: (data: unknown, status?: number) => {
+        // Debug logs removed to keep test output clean
+        // console.log("Mock API response:", JSON.stringify(data, null, 2));
+        // console.log("Response status:", status || 200);
+        return { data, status };
+      },
+    };
 
-  // deno-lint-ignore no-explicit-any
-  await handleProjectsRequest(mockContext as any);
+    // deno-lint-ignore no-explicit-any
+    await handleProjectsRequest(mockContext as any);
+  });
 });

--- a/backend/tests/node/runtime.test.ts
+++ b/backend/tests/node/runtime.test.ts
@@ -5,36 +5,16 @@
  * works correctly in a Node.js environment.
  */
 
-import process from "node:process";
-import { NodeRuntime } from "../../runtime/node.ts";
+import { describe, it, expect } from "vitest";
+import { NodeRuntime } from "../../runtime/node.js";
 
-async function runTests() {
-  console.log("🧪 Starting Node.js Runtime Tests...\n");
-
+describe("Node.js Runtime", () => {
   const runtime = new NodeRuntime();
-  let passedTests = 0;
-  let totalTests = 0;
 
-  // Helper function to run individual tests
-  async function test(name: string, testFn: () => Promise<void> | void) {
-    totalTests++;
-    try {
-      await testFn();
-      console.log(`✅ ${name}`);
-      passedTests++;
-    } catch (error: unknown) {
-      const errorMessage = error instanceof Error
-        ? error.message
-        : String(error);
-      console.log(`❌ ${name}: ${errorMessage}`);
-    }
-  }
-
-  // Test 1: Interface implementation
-  await test("Runtime interface implementation", () => {
+  it("should implement all required interface methods", () => {
     const requiredMethods = [
       "readTextFile",
-      "readTextFileSync",
+      "readTextFileSync", 
       "readBinaryFile",
       "exists",
       "stat",
@@ -49,90 +29,45 @@ async function runTests() {
     ];
 
     for (const method of requiredMethods) {
-      if (
-        typeof (runtime as unknown as Record<string, unknown>)[method] !==
-          "function"
-      ) {
-        throw new Error(`Missing method: ${method}`);
-      }
+      expect(typeof (runtime as unknown as Record<string, unknown>)[method]).toBe("function");
     }
   });
 
-  // Test 2: Environment variable access
-  await test("Environment variable access", () => {
+  it("should access environment variables", () => {
     const path = runtime.getEnv("PATH");
-    if (typeof path !== "string" || path.length === 0) {
-      throw new Error("PATH environment variable should be accessible");
-    }
+    expect(typeof path).toBe("string");
+    expect(path!.length).toBeGreaterThan(0);
   });
 
-  // Test 3: Command line arguments
-  await test("Command line arguments", () => {
+  it("should return command line arguments as array", () => {
     const args = runtime.getArgs();
-    if (!Array.isArray(args)) {
-      throw new Error("getArgs should return an array");
-    }
+    expect(Array.isArray(args)).toBe(true);
   });
 
-  // Test 4: File existence check
-  await test("File existence check", async () => {
+  it("should check file existence", async () => {
     const exists = await runtime.exists("package.json");
-    if (!exists) {
-      throw new Error("package.json should exist in backend directory");
-    }
+    expect(exists).toBe(true);
   });
 
-  // Test 5: File reading
-  await test("File reading", async () => {
+  it("should read files asynchronously", async () => {
     const content = await runtime.readTextFile("package.json");
-    if (typeof content !== "string" || content.length === 0) {
-      throw new Error("Should be able to read package.json");
-    }
+    expect(typeof content).toBe("string");
+    expect(content.length).toBeGreaterThan(0);
 
     // Verify it's actually JSON
     const parsed = JSON.parse(content);
-    if (parsed.name !== "claude-code-webui-backend") {
-      throw new Error("package.json should contain correct package name");
-    }
+    expect(parsed.name).toBe("claude-code-webui");
   });
 
-  // Test 6: Sync file reading
-  await test("Sync file reading", () => {
+  it("should read files synchronously", () => {
     const content = runtime.readTextFileSync("package.json");
-    if (typeof content !== "string" || content.length === 0) {
-      throw new Error("Should be able to read package.json synchronously");
-    }
+    expect(typeof content).toBe("string");
+    expect(content.length).toBeGreaterThan(0);
   });
 
-  // Test 7: Command execution (simple test)
-  await test("Command execution", async () => {
+  it("should execute commands", async () => {
     const result = await runtime.runCommand("echo", ["test"]);
-    if (typeof result.success !== "boolean") {
-      throw new Error(
-        "runCommand should return CommandResult with success boolean",
-      );
-    }
-    if (typeof result.stdout !== "string") {
-      throw new Error(
-        "runCommand should return CommandResult with stdout string",
-      );
-    }
+    expect(typeof result.success).toBe("boolean");
+    expect(typeof result.stdout).toBe("string");
   });
-
-  // Results
-  console.log(`\n📊 Test Results: ${passedTests}/${totalTests} tests passed`);
-
-  if (passedTests === totalTests) {
-    console.log("🎉 All tests passed! Node.js Runtime is working correctly.");
-    process.exit(0);
-  } else {
-    console.log("❌ Some tests failed. Please check the implementation.");
-    process.exit(1);
-  }
-}
-
-// Run tests
-runTests().catch((error) => {
-  console.error("💥 Test runner failed:", error);
-  process.exit(1);
 });

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    exclude: [
+      "**/node_modules/**",
+      "**/dist/**",
+    ],
+    testTimeout: 30000,
+  },
+});


### PR DESCRIPTION
## Summary
Unify backend testing infrastructure to use `npm run test` instead of `deno task test` for better consistency between development, CI, and npm publishing workflows.

## Changes
- **Makefile**: Update `test-backend` to use `npm run test` instead of `deno task test`
- **CI Workflow**: Add backend npm test step with Node.js setup in `.github/workflows/ci.yml`
- **Test Conversion**: 
  - Convert `pathUtils.test.ts` from Deno to Vitest format
  - Convert `runtime.test.ts` from standalone script to Vitest format
- **Configuration**: Add `vitest.config.ts` with proper exclusions
- **Compatibility**: Fix import paths and lint issues for Node.js compatibility

## Type of Change
- [x] 🐛 `bug` - Fixes inconsistent testing infrastructure
- [x] 🔧 `chore` - Improves development workflow

## Test Results
- **Frontend**: 44 tests ✅
- **Backend**: 9 tests ✅ (pathUtils: 2, runtime: 7)
- **Total**: 53 tests passing

## Benefits
- Consistent testing across development, CI, and npm publishing
- Node.js runtime functionality properly tested
- Better integration with npm workflow automation

## Related
- Follow-up to #166 (npm publishing automation)
- Addresses backend test failures in npm publishing workflow

🤖 Generated with [Claude Code](https://claude.ai/code)