### PR TITLE
fix: add shebang to CLI entry point for npm global installation

### DIFF
--- a/backend/cli/node.ts
+++ b/backend/cli/node.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * Node.js-specific entry point
  *


### PR DESCRIPTION
## Summary
Add shebang line to CLI entry point to fix npm global installation execution.

## Problem
The npm publishing workflow was failing because the `claude-code-webui --version` command couldn't execute after global installation. The issue was that the CLI entry point `dist/cli/node.js` was missing the shebang line (`#\!/usr/bin/env node`), making it non-executable.

## Solution
- Add `#\!/usr/bin/env node` shebang to `backend/cli/node.ts`
- esbuild preserves the shebang in the bundled output
- npm can now correctly install and execute the CLI globally

## Type of Change
- [x] 🐛 `bug` - Fixes npm package executable issue

## Test Results
✅ **Local testing passed:**
```bash
npm pack
npm install -g claude-code-webui-0.1.32.tgz
claude-code-webui --version  # Returns: 0.1.32
```

## Related
- Fixes npm publishing workflow test failure in #166
- Addresses issue found in GitHub Actions: https://github.com/sugyan/claude-code-webui/actions/runs/16223933040/job/45811267947

🤖 Generated with [Claude Code](https://claude.ai/code)