### PR TITLE
fix: resolve static path for npm global installation

### DIFF
--- a/backend/cli/node.ts
+++ b/backend/cli/node.ts
@@ -10,6 +10,8 @@ import { createApp } from "../app.ts";
 import { NodeRuntime } from "../runtime/node.ts";
 import { parseCliArgs } from "./args.ts";
 import { validateClaudeCli } from "./validation.ts";
+import { fileURLToPath } from "node:url";
+import { dirname, join, relative } from "node:path";
 
 async function main(runtime: NodeRuntime) {
   // Parse CLI arguments
@@ -22,10 +24,16 @@ async function main(runtime: NodeRuntime) {
     console.log("🐛 Debug mode enabled");
   }
 
+  // Calculate static path relative to current working directory
+  // Node.js 20.11.0+ compatible with fallback for older versions
+  const __dirname = import.meta.dirname ?? dirname(fileURLToPath(import.meta.url));
+  const staticAbsPath = join(__dirname, "../static");
+  const staticRelPath = relative(process.cwd(), staticAbsPath);
+
   // Create application
   const app = createApp(runtime, {
     debugMode: args.debug,
-    staticPath: "./dist/static",
+    staticPath: staticRelPath,
     claudePath: validatedClaudePath,
   });
 

--- a/backend/cli/node.ts
+++ b/backend/cli/node.ts
@@ -28,7 +28,11 @@ async function main(runtime: NodeRuntime) {
   // Node.js 20.11.0+ compatible with fallback for older versions
   const __dirname = import.meta.dirname ?? dirname(fileURLToPath(import.meta.url));
   const staticAbsPath = join(__dirname, "../static");
-  const staticRelPath = relative(process.cwd(), staticAbsPath);
+  let staticRelPath = relative(process.cwd(), staticAbsPath);
+  // Handle edge case where relative() returns empty string
+  if (staticRelPath === '') {
+    staticRelPath = '.';
+  }
 
   // Create application
   const app = createApp(runtime, {


### PR DESCRIPTION
## Summary

Fixes static file serving when the `claude-code-webui` package is installed globally via npm. The previous implementation used a hardcoded relative path `"./dist/static"` which resolved relative to the user's current working directory instead of the package installation directory, causing 404 errors for CSS, JS, and HTML files.

## Problem

- **Issue**: Static assets (CSS, JS, HTML) were not loading when package was installed globally via npm
- **Root cause**: The path `"./dist/static"` resolved from user's cwd instead of package location
- **Constraint**: `@hono/node-server/serve-static` only accepts relative paths

## Solution

- Calculate package directory using `import.meta.dirname` with fallback for older Node.js versions
- Convert absolute static path to relative path using `path.relative(process.cwd(), staticAbsPath)`
- Ensures compatibility with `@hono/node-server/serve-static` requirements
- Works for both local development and global npm installation

## Technical Details

**Before:**
```javascript
staticPath: "./dist/static", // Always resolves from user's cwd
```

**After:**
```javascript
const __dirname = import.meta.dirname ?? dirname(fileURLToPath(import.meta.url));
const staticAbsPath = join(__dirname, "../static");
const staticRelPath = relative(process.cwd(), staticAbsPath);
staticPath: staticRelPath, // Properly calculates relative path from package location
```

## Test Plan

- [x] All existing tests pass
- [x] Package builds successfully
- [x] CLI functionality works locally
- [x] Static files included in npm package
- [x] Quality checks pass (formatting, linting, type checking)

## Compatibility

- ✅ Node.js 20.11.0+ (uses `import.meta.dirname`)
- ✅ Node.js 18.0.0+ (uses fallback with `fileURLToPath` and `dirname`)
- ✅ Local development workflow unchanged
- ✅ Deno runtime unaffected

This resolves the critical issue where globally installed npm users couldn't access the web interface due to missing static assets.

🤖 Generated with [Claude Code](https://claude.ai/code)