### PR TITLE
fix: add prepack script to include README and LICENSE in npm package

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -48,6 +48,7 @@
     "test": "vitest --run --reporter=verbose",
     "lint": "eslint **/*.ts --ignore-pattern dist/",
     "typecheck": "tsc --noEmit",
+    "prepack": "cp ../README.md ./ && cp ../LICENSE ./",
     "prepublishOnly": "npm run build && npm run test"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Adds `prepack` script to `backend/package.json` that copies `../README.md` and `../LICENSE` to the backend directory before packaging
- Resolves issue #152 where npm package shows "This package does not have a README"
- Tested with `npm pack --dry-run` to verify files are included correctly

## Type of Change
- [x] 🐛 `bug` - Bug fix (non-breaking change which fixes an issue)
- [x] 🖥️ `backend` - Backend-related changes

## Test Plan
- [x] Verified `npm pack --dry-run` includes README.md (7.4kB) and LICENSE (1.1kB) files
- [x] All quality checks pass
- [x] No changes to existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)