### PR TITLE
Change version option from -V to -v to match Claude CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The backend server supports the following command-line options:
 | `--claude-path <path>` | Path to claude executable (overrides automatic detection) | Auto-detect |
 | `-d, --debug`          | Enable debug mode                                         | false       |
 | `-h, --help`           | Show help message                                         | -           |
-| `-V, --version`        | Show version                                              | -           |
+| `-v, --version`        | Show version                                              | -           |
 
 ### Environment Variables
 

--- a/backend/cli/args.ts
+++ b/backend/cli/args.ts
@@ -25,7 +25,7 @@ export function parseCliArgs(runtime: Runtime): ParsedArgs {
   // Configure program
   program
     .name("claude-code-webui")
-    .version(version)
+    .version(version, "-v, --version", "display version number")
     .description("Claude Code Web UI Backend Server")
     .option(
       "-p, --port <port>",


### PR DESCRIPTION
## Summary
- Change Commander.js version option from `-V` to `-v` to match Claude CLI convention
- Update README.md CLI options documentation to reflect the change
- This creates consistency with Claude CLI which uses `-v, --version`

## Changes
- Modified `backend/cli/args.ts` to use `.version(version, '-v, --version', 'display version number')`
- Updated `README.md` CLI options table to show `-v, --version` instead of `-V, --version`

## Test Plan
- [x] Verified `-v` option works correctly
- [x] Verified `--version` long form still works
- [x] Confirmed `-V` no longer works (breaking change)
- [x] Help text displays correct version option
- [x] All quality checks pass

## Breaking Change
This is a breaking change for users who were using the `-V` option. They will need to use `-v` instead.

🤖 Generated with [Claude Code](https://claude.ai/code)