### PR TITLE
feat: simplify Node.js runtime with Hono v1.17.0 absolute path support

### DIFF
--- a/backend/cli/node.ts
+++ b/backend/cli/node.ts
@@ -11,7 +11,7 @@ import { NodeRuntime } from "../runtime/node.ts";
 import { parseCliArgs } from "./args.ts";
 import { validateClaudeCli } from "./validation.ts";
 import { fileURLToPath } from "node:url";
-import { dirname, join, relative } from "node:path";
+import { dirname, join } from "node:path";
 
 async function main(runtime: NodeRuntime) {
   // Parse CLI arguments
@@ -24,21 +24,16 @@ async function main(runtime: NodeRuntime) {
     console.log("🐛 Debug mode enabled");
   }
 
-  // Calculate static path relative to current working directory
+  // Use absolute path for static files (supported in @hono/node-server v1.17.0+)
   // Node.js 20.11.0+ compatible with fallback for older versions
   const __dirname =
     import.meta.dirname ?? dirname(fileURLToPath(import.meta.url));
-  const staticAbsPath = join(__dirname, "../static");
-  let staticRelPath = relative(process.cwd(), staticAbsPath);
-  // Handle edge case where relative() returns empty string
-  if (staticRelPath === "") {
-    staticRelPath = ".";
-  }
+  const staticPath = join(__dirname, "../static");
 
   // Create application
   const app = createApp(runtime, {
     debugMode: args.debug,
-    staticPath: staticRelPath,
+    staticPath: staticPath,
     cliPath: cliPath,
   });
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-code-webui",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-webui",
-      "version": "0.1.36",
+      "version": "0.1.37",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-code": "1.0.51",
@@ -653,9 +653,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.15.0.tgz",
-      "integrity": "sha512-MjmK4l5N4dQpZ9OSWN0tCj7ejuc7WvuWMzSKtc89bnknJykAeHxzRigXBTYZk85H6Awrii6RM59iUiUluApu2A==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.17.0.tgz",
+      "integrity": "sha512-u30lnh86PYua8X1NqsV4O7aeziJq7mN0pDXUvGxIeLWVI+n/xzuSxMb1YZlQ/73LTf6Wxgp5cyhw7r5JSrCgcg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"


### PR DESCRIPTION
## Summary
- Update @hono/node-server from v1.15.0 to v1.17.0 for absolute path support
- Simplify Node.js runtime implementation by removing complex relative path calculations
- Improve code maintainability and eliminate working directory dependencies

## Changes
- **Dependency Update**: Upgraded `@hono/node-server` to v1.17.0 which adds absolute path support
- **Code Simplification**: Replaced 10 lines of complex relative path calculation with 1 line of absolute path
- **Import Cleanup**: Removed unused `relative` import from `node:path`
- **Improved Robustness**: Static file serving no longer depends on working directory

## Before/After Comparison

### Before (10 lines of complex logic)
```typescript
const staticAbsPath = join(__dirname, "../static");
let staticRelPath = relative(process.cwd(), staticAbsPath);
if (staticRelPath === "") {
  staticRelPath = ".";
}
```

### After (1 line, simple and clear)
```typescript
const staticPath = join(__dirname, "../static");
```

## Test plan
- [x] All quality checks pass (lint, typecheck, test)
- [x] Both Deno and Node.js runtimes continue to work correctly
- [x] Static file serving functions properly with absolute paths
- [x] No breaking changes to existing API

🤖 Generated with [Claude Code](https://claude.ai/code)