### PR TITLE
Release for 0.1.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.41](https://github.com/sugyan/claude-code-webui/compare/0.1.40...0.1.41) - 2025-07-26
+- feat: replace blocking modal permission dialog with inline interface by @sugyan in https://github.com/sugyan/claude-code-webui/pull/203
+- feat: add comprehensive README screenshots with optimized layout by @sugyan in https://github.com/sugyan/claude-code-webui/pull/205
+- chore: update @anthropic-ai/claude-code to version 1.0.61 by @sugyan in https://github.com/sugyan/claude-code-webui/pull/206
+
 ## [0.1.40](https://github.com/sugyan/claude-code-webui/compare/0.1.39...0.1.40) - 2025-07-22
 - feat: comprehensive Windows compatibility and configuration improvements by @sugyan in https://github.com/sugyan/claude-code-webui/pull/199
 - feat: add comprehensive GitHub issue templates by @sugyan in https://github.com/sugyan/claude-code-webui/pull/202

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-webui",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "type": "module",
   "description": "Web-based interface for the Claude Code CLI with streaming chat interface",
   "keywords": [


### PR DESCRIPTION
This pull request is for the next release as 0.1.41 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag 0.1.41 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-0.1.40" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* feat: replace blocking modal permission dialog with inline interface by @sugyan in https://github.com/sugyan/claude-code-webui/pull/203
* feat: add comprehensive README screenshots with optimized layout by @sugyan in https://github.com/sugyan/claude-code-webui/pull/205
* chore: update @anthropic-ai/claude-code to version 1.0.61 by @sugyan in https://github.com/sugyan/claude-code-webui/pull/206


**Full Changelog**: https://github.com/sugyan/claude-code-webui/compare/0.1.40...0.1.41