### PR TITLE
chore: update @anthropic-ai/claude-code to version 1.0.61

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -663,7 +663,7 @@ When updating to a new Claude Code version (e.g., 1.0.40):
    ```bash
    # For Deno: Edit backend/deno.json imports - change version number
    # "@anthropic-ai/claude-code": "npm:@anthropic-ai/claude-code@1.0.XX"
-   cd backend && rm deno.lock && deno cache main.ts
+   cd backend && rm deno.lock && deno cache cli/deno.ts
 
    # For Node.js: Edit backend/package.json - change version number
    # "@anthropic-ai/claude-code": "1.0.XX"

--- a/backend/deno.json
+++ b/backend/deno.json
@@ -19,6 +19,6 @@
     "@std/path": "jsr:@std/path@1",
     "commander": "npm:commander@^14.0.0",
     "hono": "jsr:@hono/hono@^4.8.5",
-    "@anthropic-ai/claude-code": "npm:@anthropic-ai/claude-code@1.0.51"
+    "@anthropic-ai/claude-code": "npm:@anthropic-ai/claude-code@1.0.61"
   }
 }

--- a/backend/deno.lock
+++ b/backend/deno.lock
@@ -24,12 +24,12 @@
       "jsr:@hono/hono@^4.8.5",
       "jsr:@std/assert@1",
       "jsr:@std/path@1",
-      "npm:@anthropic-ai/claude-code@1.0.51",
+      "npm:@anthropic-ai/claude-code@1.0.61",
       "npm:commander@14"
     ],
     "packageJson": {
       "dependencies": [
-        "npm:@anthropic-ai/claude-code@1.0.51",
+        "npm:@anthropic-ai/claude-code@1.0.61",
         "npm:@hono/node-server@1",
         "npm:@types/node@20",
         "npm:@typescript-eslint/eslint-plugin@8",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "claude-code-webui",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-webui",
-      "version": "0.1.39",
+      "version": "0.1.40",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/claude-code": "1.0.51",
+        "@anthropic-ai/claude-code": "1.0.61",
         "@hono/node-server": "^1.0.0",
         "commander": "^14.0.0",
         "hono": "^4.8.5"
@@ -33,13 +33,13 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@anthropic-ai/claude-code": "1.0.51"
+        "@anthropic-ai/claude-code": "1.0.61"
       }
     },
     "node_modules/@anthropic-ai/claude-code": {
-      "version": "1.0.51",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.51.tgz",
-      "integrity": "sha512-annBc4ez7nDPbp+di6bjIQGiAdmdVln4k3gAYioym2MxOEl3py5s7SsoR+dNSmfgfIHUdKBTbtXnXD5rkmO5aA==",
+      "version": "1.0.61",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.61.tgz",
+      "integrity": "sha512-+gjKzY1hsWfHoH52SgKR6E0ujCDPyyRsjyRShtZfS0urKd8VQq3D/DF3hvT3P4JJeW0YuWp5Dep0aSRON+/FFA==",
       "license": "SEE LICENSE IN README.md",
       "bin": {
         "claude": "cli.js"

--- a/backend/package.json
+++ b/backend/package.json
@@ -54,7 +54,7 @@
     "prepublishOnly": "npm run build && npm run test"
   },
   "dependencies": {
-    "@anthropic-ai/claude-code": "1.0.51",
+    "@anthropic-ai/claude-code": "1.0.61",
     "@hono/node-server": "^1.0.0",
     "commander": "^14.0.0",
     "hono": "^4.8.5"
@@ -72,6 +72,6 @@
     "vitest": "^2.0.0"
   },
   "peerDependencies": {
-    "@anthropic-ai/claude-code": "1.0.51"
+    "@anthropic-ai/claude-code": "1.0.61"
   }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,7 +15,7 @@
         "react-router-dom": "^7.6.2"
       },
       "devDependencies": {
-        "@anthropic-ai/claude-code": "1.0.51",
+        "@anthropic-ai/claude-code": "1.0.61",
         "@eslint/js": "^9.25.0",
         "@playwright/test": "^1.48.2",
         "@tailwindcss/vite": "^4.1.8",
@@ -63,9 +63,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-code": {
-      "version": "1.0.51",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.51.tgz",
-      "integrity": "sha512-annBc4ez7nDPbp+di6bjIQGiAdmdVln4k3gAYioym2MxOEl3py5s7SsoR+dNSmfgfIHUdKBTbtXnXD5rkmO5aA==",
+      "version": "1.0.61",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.61.tgz",
+      "integrity": "sha512-+gjKzY1hsWfHoH52SgKR6E0ujCDPyyRsjyRShtZfS0urKd8VQq3D/DF3hvT3P4JJeW0YuWp5Dep0aSRON+/FFA==",
       "dev": true,
       "license": "SEE LICENSE IN README.md",
       "bin": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
     "react-router-dom": "^7.6.2"
   },
   "devDependencies": {
-    "@anthropic-ai/claude-code": "1.0.51",
+    "@anthropic-ai/claude-code": "1.0.61",
     "@eslint/js": "^9.25.0",
     "@playwright/test": "^1.48.2",
     "@tailwindcss/vite": "^4.1.8",


### PR DESCRIPTION
## Summary

- Update @anthropic-ai/claude-code dependency from 1.0.51 to 1.0.61 across all configuration files
- Fix outdated documentation in CLAUDE.md (main.ts → cli/deno.ts)
- Regenerate all lock files with updated dependencies

## Type of Change

- [x] 🔧 `chore` - Maintenance, dependencies, tooling
- [x] 🖥️ `backend` - Backend-related changes  
- [x] 🎨 `frontend` - Frontend-related changes
- [x] 📚 `documentation` - Documentation update

## Changes Made

### Dependency Updates
- **Frontend**: `frontend/package.json` devDependency updated to 1.0.61
- **Backend Deno**: `backend/deno.json` import mapping updated to 1.0.61
- **Backend Node.js**: `backend/package.json` dependencies and peerDependencies updated to 1.0.61
- **Lock Files**: Regenerated `package-lock.json` files and `deno.lock`

### Documentation Fix
- **CLAUDE.md**: Fixed outdated command reference from `main.ts` to `cli/deno.ts`

## Test Plan

- [x] All quality checks pass (`make check`)
  - [x] Format check (frontend & backend)
  - [x] Lint check (frontend & backend)  
  - [x] Type check (frontend & backend)
  - [x] Tests (frontend & backend)
  - [x] Build (frontend)
- [x] Verified consistent 1.0.61 version across all configuration files
- [x] Lefthook pre-commit hooks pass successfully

🤖 Generated with [Claude Code](https://claude.ai/code)