### PR TITLE
fix: include docs/ directory in npm package for README images

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -30,6 +30,7 @@
   },
   "files": [
     "dist/",
+    "docs/",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
## Summary

- Fixes the issue where README screenshots are visible on GitHub but missing on npmjs.com
- Adds `docs/` to the `files` field in `backend/package.json` to include screenshot images in npm package distribution

## Problem

The README.md file references images in the `docs/images/` directory using relative paths, but these images were not being included in the npm package because the `files` field in package.json only included `dist/`, `README.md`, and `LICENSE`.

This meant that:
- ✅ Images display correctly on GitHub (repository has the files)
- ❌ Images are broken on npmjs.com (package doesn't include the image files)

## Solution

Added `"docs/"` to the `files` array in `backend/package.json`. Now the npm package will include:
- `dist/` - Application code
- `docs/` - Screenshots and documentation images  
- `README.md` - Documentation
- `LICENSE` - License file

## Type of Change

- [x] 🐛 `bug` - Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 `chore` - Maintenance, dependencies, tooling

## Test Plan

After this change is merged and a new version is published to npm:
1. Visit the package page on npmjs.com
2. Verify that all README screenshots display correctly
3. Confirm that the relative image paths work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)