### PR TITLE
Release for 0.1.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.42](https://github.com/sugyan/claude-code-webui/compare/0.1.41...0.1.42) - 2025-07-27
+- fix: include docs/ directory in npm package for README images by @sugyan in https://github.com/sugyan/claude-code-webui/pull/207
+- fix: add permissions to demo-comparison workflow for issue creation by @sugyan in https://github.com/sugyan/claude-code-webui/pull/209
+- chore: cleanup documentation and remove unused files by @sugyan in https://github.com/sugyan/claude-code-webui/pull/210
+
 ## [0.1.41](https://github.com/sugyan/claude-code-webui/compare/0.1.40...0.1.41) - 2025-07-26
 - feat: replace blocking modal permission dialog with inline interface by @sugyan in https://github.com/sugyan/claude-code-webui/pull/203
 - feat: add comprehensive README screenshots with optimized layout by @sugyan in https://github.com/sugyan/claude-code-webui/pull/205

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-webui",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "type": "module",
   "description": "Web-based interface for the Claude Code CLI with streaming chat interface",
   "keywords": [


### PR DESCRIPTION
This pull request is for the next release as 0.1.42 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag 0.1.42 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-0.1.41" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* fix: include docs/ directory in npm package for README images by @sugyan in https://github.com/sugyan/claude-code-webui/pull/207
* fix: add permissions to demo-comparison workflow for issue creation by @sugyan in https://github.com/sugyan/claude-code-webui/pull/209
* chore: cleanup documentation and remove unused files by @sugyan in https://github.com/sugyan/claude-code-webui/pull/210


**Full Changelog**: https://github.com/sugyan/claude-code-webui/compare/0.1.41...0.1.42