### PR TITLE
fix: add permissions to demo-comparison workflow for issue creation

### DIFF
--- a/.github/workflows/demo-comparison.yml
+++ b/.github/workflows/demo-comparison.yml
@@ -22,6 +22,9 @@ jobs:
     timeout-minutes: 15
     # Only run if the triggering workflow was successful
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: read
+      issues: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

Fixes the Demo Comparison GitHub Action that was failing with "Resource not accessible by integration" error when attempting to create issues for README updates.

## Problem

The demo-comparison workflow was failing at the "Create issue for README update" step due to insufficient permissions. The GitHub Actions token didn't have the necessary `issues: write` permission to create issues when demo video differences were detected.

## Solution

Added explicit `permissions` section to the `compare-demos` job in `.github/workflows/demo-comparison.yml`:

```yaml
permissions:
  contents: read
  issues: write
```

This provides the minimal required permissions:
- `contents: read` - For repository access and file reading
- `issues: write` - For creating issues when demo differences are detected

## Testing

- ✅ All quality checks pass (format, lint, typecheck, tests, build)
- ✅ No impact on other workflows (permissions are job-specific)
- ✅ Follows security best practices (minimal required permissions)

## Type of Change

- [x] 🐛 `bug` - Bug fix (non-breaking change which fixes an issue)
- [x] 🖥️ `backend` - Backend-related changes

🤖 Generated with [Claude Code](https://claude.ai/code)