### PR TITLE
fix: include images in npm package for README display

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -35,3 +35,8 @@ cli/version.ts
 
 # Frontend build output (copied for testing)
 static/
+
+# Files copied during prepack for npm distribution
+README.md
+LICENSE
+docs/

--- a/backend/scripts/prepack.js
+++ b/backend/scripts/prepack.js
@@ -3,12 +3,12 @@
 /**
  * Prepack script - Copy required files for npm package
  *
- * This script copies README.md and LICENSE from the project root
+ * This script copies README.md, LICENSE, and docs/images/ from the project root
  * to the backend directory for npm package distribution.
  * Replaces the Unix-specific `cp` command for Windows compatibility.
  */
 
-import { copyFileSync, existsSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, readdirSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import process from "node:process";
@@ -21,8 +21,38 @@ const projectRoot = join(__dirname, "../..");
 const backendDir = join(__dirname, "..");
 const readmePath = join(projectRoot, "README.md");
 const licensePath = join(projectRoot, "LICENSE");
+const docsPath = join(projectRoot, "docs");
 const targetReadmePath = join(backendDir, "README.md");
 const targetLicensePath = join(backendDir, "LICENSE");
+const targetDocsPath = join(backendDir, "docs");
+
+/**
+ * Recursively copy directory and its contents
+ * @param {string} src - Source directory path
+ * @param {string} dest - Destination directory path
+ */
+function copyDirectoryRecursive(src, dest) {
+  if (!existsSync(src)) {
+    return;
+  }
+
+  if (!existsSync(dest)) {
+    mkdirSync(dest, { recursive: true });
+  }
+
+  const items = readdirSync(src);
+  for (const item of items) {
+    const srcPath = join(src, item);
+    const destPath = join(dest, item);
+    const stat = statSync(srcPath);
+
+    if (stat.isDirectory()) {
+      copyDirectoryRecursive(srcPath, destPath);
+    } else {
+      copyFileSync(srcPath, destPath);
+    }
+  }
+}
 
 // Copy README.md
 if (existsSync(readmePath)) {
@@ -50,6 +80,19 @@ if (existsSync(licensePath)) {
 } else {
   console.error("❌ LICENSE not found at:", licensePath);
   process.exit(1);
+}
+
+// Copy docs directory
+if (existsSync(docsPath)) {
+  try {
+    copyDirectoryRecursive(docsPath, targetDocsPath);
+    console.log("✅ Copied docs/");
+  } catch (error) {
+    console.error("❌ Failed to copy docs/:", error.message);
+    process.exit(1);
+  }
+} else {
+  console.warn("⚠️  docs/ directory not found at:", docsPath);
 }
 
 console.log("✅ Prepack completed successfully");


### PR DESCRIPTION
## Summary

Fixed npm package image display issue where README screenshots were not visible on https://www.npmjs.com/package/claude-code-webui.

- Extended `backend/scripts/prepack.js` to copy `docs/images/` directory during packaging
- Added recursive directory copying function for cross-platform compatibility  
- Updated `backend/.gitignore` to exclude copied files from git tracking

## Changes

- [x] 🐛 `bug` - Bug fix (images not displaying in npm package)
- [x] 🖥️ `backend` - Backend packaging changes

## Problem

The npm package was missing image files because:
1. Package is published from `backend/` directory as root
2. `docs/images/` exists at project root, not in `backend/`
3. Relative paths in README pointed to non-existent files in published package

## Solution

- **prepack.js**: Added `copyDirectoryRecursive()` function to copy `docs/` from project root to `backend/docs/` during npm packaging
- **gitignore**: Added copied files to ignore list so they don't pollute git history
- **Automation**: Process runs automatically during `npm publish` via prepack hook

## Test Plan

- [x] Local testing: `npm pack --dry-run` confirms images are included
- [x] Quality checks: All tests, linting, and formatting pass
- [ ] Verify on next npm publish that images display correctly

🤖 Generated with [Claude Code](https://claude.ai/code)