### PR TITLE
fix: use absolute URLs for README images to properly display on npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 | Desktop Interface                                                                             | Mobile Experience                                                                           |
 | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| <img src="docs/images/screenshot-desktop-basic-dark.png" alt="Desktop Interface" width="600"> | <img src="docs/images/screenshot-mobile-basic-dark.png" alt="Mobile Interface" width="250"> |
+| <img src="https://github.com/sugyan/claude-code-webui/raw/main/docs/images/screenshot-desktop-basic-dark.png" alt="Desktop Interface" width="600"> | <img src="https://github.com/sugyan/claude-code-webui/raw/main/docs/images/screenshot-mobile-basic-dark.png" alt="Mobile Interface" width="250"> |
 | _Chat-based coding interface with instant responses and ready input field_                    | _Mobile-optimized chat experience with touch-friendly design_                               |
 
 </div>
@@ -28,7 +28,7 @@
 
 | Desktop (Light)                                                                            | Mobile (Light)                                                                           |
 | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
-| <img src="docs/images/screenshot-desktop-basic.png" alt="Desktop Light Theme" width="600"> | <img src="docs/images/screenshot-mobile-basic.png" alt="Mobile Light Theme" width="250"> |
+| <img src="https://github.com/sugyan/claude-code-webui/raw/main/docs/images/screenshot-desktop-basic.png" alt="Desktop Light Theme" width="600"> | <img src="https://github.com/sugyan/claude-code-webui/raw/main/docs/images/screenshot-mobile-basic.png" alt="Mobile Light Theme" width="250"> |
 | _Clean light interface for daytime coding sessions_                                        | _iPhone SE optimized light theme interface_                                              |
 
 </div>
@@ -42,7 +42,7 @@
 
 | Desktop Permission Dialog                                                                              | Mobile Permission Dialog                                                                              |
 | ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
-| <img src="docs/images/screenshot-desktop-fileOperations-dark.png" alt="Permission Dialog" width="600"> | <img src="docs/images/screenshot-mobile-fileOperations-dark.png" alt="Mobile Permission" width="250"> |
+| <img src="https://github.com/sugyan/claude-code-webui/raw/main/docs/images/screenshot-desktop-fileOperations-dark.png" alt="Permission Dialog" width="600"> | <img src="https://github.com/sugyan/claude-code-webui/raw/main/docs/images/screenshot-mobile-fileOperations-dark.png" alt="Mobile Permission" width="250"> |
 | _Secure tool access with granular permission controls and clear approval workflow_                     | _Touch-optimized permission interface for mobile devices_                                             |
 
 </div>

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -39,4 +39,3 @@ static/
 # Files copied during prepack for npm distribution
 README.md
 LICENSE
-docs/

--- a/backend/package.json
+++ b/backend/package.json
@@ -30,7 +30,6 @@
   },
   "files": [
     "dist/",
-    "docs/",
     "README.md",
     "LICENSE"
   ],

--- a/backend/scripts/prepack.js
+++ b/backend/scripts/prepack.js
@@ -3,12 +3,12 @@
 /**
  * Prepack script - Copy required files for npm package
  *
- * This script copies README.md, LICENSE, and docs/images/ from the project root
+ * This script copies README.md and LICENSE from the project root
  * to the backend directory for npm package distribution.
  * Replaces the Unix-specific `cp` command for Windows compatibility.
  */
 
-import { copyFileSync, existsSync, mkdirSync, readdirSync, statSync } from "node:fs";
+import { copyFileSync, existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import process from "node:process";
@@ -21,38 +21,9 @@ const projectRoot = join(__dirname, "../..");
 const backendDir = join(__dirname, "..");
 const readmePath = join(projectRoot, "README.md");
 const licensePath = join(projectRoot, "LICENSE");
-const docsPath = join(projectRoot, "docs");
 const targetReadmePath = join(backendDir, "README.md");
 const targetLicensePath = join(backendDir, "LICENSE");
-const targetDocsPath = join(backendDir, "docs");
 
-/**
- * Recursively copy directory and its contents
- * @param {string} src - Source directory path
- * @param {string} dest - Destination directory path
- */
-function copyDirectoryRecursive(src, dest) {
-  if (!existsSync(src)) {
-    return;
-  }
-
-  if (!existsSync(dest)) {
-    mkdirSync(dest, { recursive: true });
-  }
-
-  const items = readdirSync(src);
-  for (const item of items) {
-    const srcPath = join(src, item);
-    const destPath = join(dest, item);
-    const stat = statSync(srcPath);
-
-    if (stat.isDirectory()) {
-      copyDirectoryRecursive(srcPath, destPath);
-    } else {
-      copyFileSync(srcPath, destPath);
-    }
-  }
-}
 
 // Copy README.md
 if (existsSync(readmePath)) {
@@ -82,17 +53,5 @@ if (existsSync(licensePath)) {
   process.exit(1);
 }
 
-// Copy docs directory
-if (existsSync(docsPath)) {
-  try {
-    copyDirectoryRecursive(docsPath, targetDocsPath);
-    console.log("✅ Copied docs/");
-  } catch (error) {
-    console.error("❌ Failed to copy docs/:", error.message);
-    process.exit(1);
-  }
-} else {
-  console.warn("⚠️  docs/ directory not found at:", docsPath);
-}
 
 console.log("✅ Prepack completed successfully");


### PR DESCRIPTION
## Summary

This PR fixes the npm package image display issue by using a simpler and more reliable approach: **absolute URLs in the README**.

## Problem with Previous Approach (#214)

PR #214 attempted to copy `docs/` during prepack, but this didn't work because:
- npm converts relative image paths to GitHub URLs based on the **package root** (`backend/`)
- Our images are at project root (`docs/images/`), not package root (`backend/docs/images/`)  
- Result: npm created incorrect URLs like `https://raw.githubusercontent.com/.../backend/docs/images/...`

## New Solution: Absolute URLs

- [x] 🐛 `bug` - Bug fix (images not displaying in npm package)
- [x] 🖥️ `backend` - Backend packaging cleanup

### Changes Made

1. **README.md**: Convert all image paths to absolute GitHub URLs
   - `docs/images/*.png` → `https://github.com/sugyan/claude-code-webui/raw/main/docs/images/*.png`
   - Affects: Desktop/mobile screenshots (dark), light theme screenshots, permission dialog screenshots

2. **Cleanup unnecessary complexity from #214**:
   - **prepack.js**: Remove docs/ copying logic and `copyDirectoryRecursive` function
   - **package.json**: Remove `"docs/"` from files array  
   - **.gitignore**: Remove `docs/` entry

## Benefits of This Approach

✅ **Reliable**: Works on both GitHub and npm without platform-specific logic  
✅ **Simple**: No complex build scripts or prepack manipulations  
✅ **Maintainable**: Clear what's happening, easy to update  
✅ **Future-proof**: Absolute URLs work regardless of npm's markdown processing changes

## Test Plan

- [x] Quality checks pass (linting, tests, typecheck)
- [x] Local verification: absolute URLs work in GitHub markdown
- [ ] Next npm publish will confirm images display on npm package page

## Root Cause Analysis

The issue was **npm's automatic relative-to-absolute URL conversion** using the wrong base path. Instead of fighting this behavior with complex workarounds, we now work with it by providing the correct absolute URLs from the start.

**Supersedes #214** - the previous approach was overcomplicated and didn't address the root cause.

🤖 Generated with [Claude Code](https://claude.ai/code)