### PR TITLE
feat: make demo page available only in development mode

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,7 +21,7 @@ function App() {
         <Routes>
           <Route path="/" element={<ProjectSelector />} />
           <Route path="/projects/*" element={<ChatPage />} />
-          {isDevelopment() && DemoPage && (
+          {DemoPage && (
             <Route
               path="/demo"
               element={

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,18 @@
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import { Suspense, lazy } from "react";
 import { ProjectSelector } from "./components/ProjectSelector";
 import { ChatPage } from "./components/ChatPage";
-import { DemoPage } from "./components/DemoPage";
 import { EnterBehaviorProvider } from "./contexts/EnterBehaviorContext";
+import { isDevelopment } from "./utils/environment";
+
+// Lazy load DemoPage only in development
+const DemoPage = isDevelopment()
+  ? lazy(() =>
+      import("./components/DemoPage").then((module) => ({
+        default: module.DemoPage,
+      })),
+    )
+  : null;
 
 function App() {
   return (
@@ -11,7 +21,16 @@ function App() {
         <Routes>
           <Route path="/" element={<ProjectSelector />} />
           <Route path="/projects/*" element={<ChatPage />} />
-          <Route path="/demo" element={<DemoPage />} />
+          {isDevelopment() && DemoPage && (
+            <Route
+              path="/demo"
+              element={
+                <Suspense fallback={<div>Loading demo...</div>}>
+                  <DemoPage />
+                </Suspense>
+              }
+            />
+          )}
         </Routes>
       </Router>
     </EnterBehaviorProvider>

--- a/frontend/src/utils/environment.ts
+++ b/frontend/src/utils/environment.ts
@@ -1,0 +1,19 @@
+/**
+ * Environment utility functions for development/production detection
+ */
+
+/**
+ * Check if the app is running in development mode
+ * @returns true if in development mode, false in production
+ */
+export function isDevelopment(): boolean {
+  return import.meta.env.DEV;
+}
+
+/**
+ * Check if the app is running in production mode
+ * @returns true if in production mode, false in development
+ */
+export function isProduction(): boolean {
+  return import.meta.env.PROD;
+}


### PR DESCRIPTION
## Summary

- Add environment utility for development/production detection using Vite's `import.meta.env.DEV`
- Conditionally load DemoPage with lazy loading in development only
- Exclude demo-related code from production builds to reduce bundle size
- Demo route `/demo` is now only available when running `npm run dev`

## Benefits

- **Development**: Demo page continues to work normally with `/demo` route
- **Production**: Demo-related code is completely excluded from bundle via tree-shaking
- **Bundle Size**: Reduces production build size by excluding unused demo components and utilities
- **Clean Architecture**: Clear separation between development and production features

## Technical Implementation

- Created `utils/environment.ts` with `isDevelopment()` utility
- Modified `App.tsx` to conditionally render demo route using React.lazy
- Vite's build-time environment variable replacement enables dead code elimination
- All demo-related imports (`DemoPage`, `useDemoAutomation`, `mockResponseGenerator`) are excluded from production builds

## Test Plan

- [x] ✅ Verified demo page works in development (`npm run dev`)
- [x] ✅ Confirmed demo-related code is excluded from production build (`npm run build`)
- [x] ✅ All quality checks pass (format, lint, typecheck, tests)

🤖 Generated with [Claude Code](https://claude.ai/code)