### PR TITLE
Release for 0.1.46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.46](https://github.com/sugyan/claude-code-webui/compare/0.1.45...0.1.46) - 2025-08-13
+- feat: implement LogTape logging system for debug log control by @sugyan in https://github.com/sugyan/claude-code-webui/pull/220
+- feat: simplify runtime abstraction using Node.js standard modules by @sugyan in https://github.com/sugyan/claude-code-webui/pull/223
+- feat: add permission mode support and unify localStorage management (#132) by @sugyan in https://github.com/sugyan/claude-code-webui/pull/226
+- feat: Backend Permission Mode Support by @sugyan in https://github.com/sugyan/claude-code-webui/pull/227
+- fix: improve logger output by removing emojis and excessive indentation by @sugyan in https://github.com/sugyan/claude-code-webui/pull/229
+- feat: complete ExitPlanMode implementation with UI integration by @sugyan in https://github.com/sugyan/claude-code-webui/pull/230
+- feat: implement session-scoped permission mode state management by @sugyan in https://github.com/sugyan/claude-code-webui/pull/232
+- fix: parse JSON theme value from localStorage in index.html by @sugyan in https://github.com/sugyan/claude-code-webui/pull/233
+- feat: update @anthropic-ai/claude-code dependency to 1.0.77 by @sugyan in https://github.com/sugyan/claude-code-webui/pull/234
+
 ## [0.1.45](https://github.com/sugyan/claude-code-webui/compare/0.1.44...0.1.45) - 2025-07-31
 - feat: make demo page available only in development mode by @sugyan in https://github.com/sugyan/claude-code-webui/pull/217
 - fix: add Windows .cmd parsing fallback for node.exe colocated environments by @sugyan in https://github.com/sugyan/claude-code-webui/pull/219

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-webui",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "type": "module",
   "description": "Web-based interface for the Claude Code CLI with streaming chat interface",
   "keywords": [


### PR DESCRIPTION
This pull request is for the next release as 0.1.46 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag 0.1.46 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-0.1.45" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* feat: implement LogTape logging system for debug log control by @sugyan in https://github.com/sugyan/claude-code-webui/pull/220
* feat: simplify runtime abstraction using Node.js standard modules by @sugyan in https://github.com/sugyan/claude-code-webui/pull/223
* feat: add permission mode support and unify localStorage management (#132) by @sugyan in https://github.com/sugyan/claude-code-webui/pull/226
* feat: Backend Permission Mode Support by @sugyan in https://github.com/sugyan/claude-code-webui/pull/227
* fix: improve logger output by removing emojis and excessive indentation by @sugyan in https://github.com/sugyan/claude-code-webui/pull/229
* feat: complete ExitPlanMode implementation with UI integration by @sugyan in https://github.com/sugyan/claude-code-webui/pull/230
* feat: implement session-scoped permission mode state management by @sugyan in https://github.com/sugyan/claude-code-webui/pull/232
* fix: parse JSON theme value from localStorage in index.html by @sugyan in https://github.com/sugyan/claude-code-webui/pull/233
* feat: update @anthropic-ai/claude-code dependency to 1.0.77 by @sugyan in https://github.com/sugyan/claude-code-webui/pull/234


**Full Changelog**: https://github.com/sugyan/claude-code-webui/compare/0.1.45...0.1.46