### PR TITLE
fix: parse JSON theme value from localStorage in index.html

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,7 +8,15 @@
     <script>
       // Prevent flash of unstyled content by setting theme class early
       (function () {
-        const theme = localStorage.getItem("claude-code-webui-theme");
+        const storedTheme = localStorage.getItem("claude-code-webui-theme");
+        let theme = null;
+        try {
+          theme = storedTheme ? JSON.parse(storedTheme) : null;
+        } catch {
+          // If parsing fails, fall back to null
+          theme = null;
+        }
+        
         if (
           theme === "dark" ||
           (!theme && window.matchMedia("(prefers-color-scheme: dark)").matches)


### PR DESCRIPTION
## Type of Change

- [x] 🐛 `bug` - Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ `feature` - New feature (non-breaking change which adds functionality)
- [ ] 💥 `breaking` - Breaking change
- [ ] 📚 `documentation` - Documentation update
- [ ] ⚡ `performance` - Performance improvement
- [ ] 🔨 `refactor` - Code refactoring
- [ ] 🧪 `test` - Adding or updating tests
- [ ] 🔧 `chore` - Maintenance, dependencies, tooling
- [ ] 🖥️ `backend` - Backend-related changes
- [x] 🎨 `frontend` - Frontend-related changes

## Summary

Fixes the issue where dark mode was not being applied on initial page load (`/`).

## Problem

- `storage.ts` uses `JSON.stringify()` to store theme values in localStorage
- This results in localStorage containing `"dark"` (with quotes) instead of `dark`  
- `index.html` was comparing the raw localStorage value with the string `"dark"` 
- The comparison `"dark" === "dark"` failed, causing dark mode not to be applied

## Solution

- Added proper JSON parsing in `index.html` with error handling
- Now correctly parses the JSON-stringified theme value from localStorage
- Maintains fallback behavior when parsing fails

## Test Plan

- [x] Set theme to dark mode in the app
- [x] Refresh the page at `/` route  
- [x] Verify dark mode is properly applied from the start
- [x] All existing tests pass
- [x] Build succeeds

Fixes dark mode initialization on project selector page.