### PR TITLE
feat: update @anthropic-ai/claude-code dependency to 1.0.77

### DIFF
--- a/backend/deno.json
+++ b/backend/deno.json
@@ -24,7 +24,7 @@
     "node:process": "node:process",
     "commander": "npm:commander@^14.0.0",
     "hono": "jsr:@hono/hono@^4.8.5",
-    "@anthropic-ai/claude-code": "npm:@anthropic-ai/claude-code@1.0.61",
+    "@anthropic-ai/claude-code": "npm:@anthropic-ai/claude-code@1.0.77",
     "@logtape/logtape": "jsr:@logtape/logtape@^1.0.0",
     "@logtape/pretty": "jsr:@logtape/pretty@^1.0.0"
   }

--- a/backend/deno.lock
+++ b/backend/deno.lock
@@ -38,12 +38,12 @@
       "jsr:@logtape/pretty@1",
       "jsr:@std/assert@1",
       "jsr:@std/path@1",
-      "npm:@anthropic-ai/claude-code@1.0.61",
+      "npm:@anthropic-ai/claude-code@1.0.77",
       "npm:commander@14"
     ],
     "packageJson": {
       "dependencies": [
-        "npm:@anthropic-ai/claude-code@1.0.61",
+        "npm:@anthropic-ai/claude-code@1.0.77",
         "npm:@hono/node-server@1",
         "npm:@logtape/logtape@1",
         "npm:@logtape/pretty@1",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.45",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/claude-code": "1.0.61",
+        "@anthropic-ai/claude-code": "1.0.77",
         "@hono/node-server": "^1.0.0",
         "@logtape/logtape": "^1.0.0",
         "@logtape/pretty": "^1.0.0",
@@ -35,13 +35,13 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@anthropic-ai/claude-code": "1.0.61"
+        "@anthropic-ai/claude-code": "1.0.77"
       }
     },
     "node_modules/@anthropic-ai/claude-code": {
-      "version": "1.0.61",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.61.tgz",
-      "integrity": "sha512-+gjKzY1hsWfHoH52SgKR6E0ujCDPyyRsjyRShtZfS0urKd8VQq3D/DF3hvT3P4JJeW0YuWp5Dep0aSRON+/FFA==",
+      "version": "1.0.77",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.77.tgz",
+      "integrity": "sha512-P4jQ9bd9DEcgQUXb94gh8h7bnconmS2qE3eGUHyxNAi8fhSDqA038fmduCKZ/0wCVGPaldYoFIaO35M/ChRtGA==",
       "license": "SEE LICENSE IN README.md",
       "bin": {
         "claude": "cli.js"

--- a/backend/package.json
+++ b/backend/package.json
@@ -54,7 +54,7 @@
     "prepublishOnly": "npm run build && npm run test"
   },
   "dependencies": {
-    "@anthropic-ai/claude-code": "1.0.61",
+    "@anthropic-ai/claude-code": "1.0.77",
     "@hono/node-server": "^1.0.0",
     "@logtape/logtape": "^1.0.0",
     "@logtape/pretty": "^1.0.0",
@@ -74,6 +74,6 @@
     "vitest": "^2.0.0"
   },
   "peerDependencies": {
-    "@anthropic-ai/claude-code": "1.0.61"
+    "@anthropic-ai/claude-code": "1.0.77"
   }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,7 +15,7 @@
         "react-router-dom": "^7.6.2"
       },
       "devDependencies": {
-        "@anthropic-ai/claude-code": "1.0.61",
+        "@anthropic-ai/claude-code": "1.0.77",
         "@eslint/js": "^9.25.0",
         "@playwright/test": "^1.48.2",
         "@tailwindcss/vite": "^4.1.8",
@@ -63,9 +63,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-code": {
-      "version": "1.0.61",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.61.tgz",
-      "integrity": "sha512-+gjKzY1hsWfHoH52SgKR6E0ujCDPyyRsjyRShtZfS0urKd8VQq3D/DF3hvT3P4JJeW0YuWp5Dep0aSRON+/FFA==",
+      "version": "1.0.77",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.77.tgz",
+      "integrity": "sha512-P4jQ9bd9DEcgQUXb94gh8h7bnconmS2qE3eGUHyxNAi8fhSDqA038fmduCKZ/0wCVGPaldYoFIaO35M/ChRtGA==",
       "dev": true,
       "license": "SEE LICENSE IN README.md",
       "bin": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
     "react-router-dom": "^7.6.2"
   },
   "devDependencies": {
-    "@anthropic-ai/claude-code": "1.0.61",
+    "@anthropic-ai/claude-code": "1.0.77",
     "@eslint/js": "^9.25.0",
     "@playwright/test": "^1.48.2",
     "@tailwindcss/vite": "^4.1.8",

--- a/frontend/src/hooks/useClaudeStreaming.test.ts
+++ b/frontend/src/hooks/useClaudeStreaming.test.ts
@@ -28,6 +28,7 @@ describe("useClaudeStreaming", () => {
       mcp_servers: [],
       model: "claude-3-sonnet",
       permissionMode: "default" as const,
+      slash_commands: [],
     };
 
     const streamLine = JSON.stringify({
@@ -153,6 +154,7 @@ describe("useClaudeStreaming", () => {
       session_id: "test-session-789",
       total_cost_usd: 0.001,
       usage: { input_tokens: 10, output_tokens: 5 },
+      permission_denials: [],
     };
 
     const streamLine = JSON.stringify({
@@ -189,6 +191,7 @@ describe("useClaudeStreaming", () => {
       mcp_servers: [],
       model: "claude-3-sonnet",
       permissionMode: "default" as const,
+      slash_commands: [],
     };
 
     const streamLine = JSON.stringify({

--- a/frontend/src/utils/mockResponseGenerator.ts
+++ b/frontend/src/utils/mockResponseGenerator.ts
@@ -49,6 +49,7 @@ export function createSystemMessage(
     mcp_servers: [],
     model: "claude-3-5-sonnet-20241022",
     permissionMode: "default",
+    slash_commands: [],
   };
 }
 
@@ -130,6 +131,7 @@ export function createResultMessage(
       output_tokens: outputTokens,
       total_tokens: inputTokens + outputTokens,
     },
+    permission_denials: [],
   };
 }
 


### PR DESCRIPTION
## Type of Change

- [ ] 🐛 `bug` - Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ `feature` - New feature (non-breaking change which adds functionality)
- [ ] 💥 `breaking` - Breaking change
- [ ] 📚 `documentation` - Documentation update
- [ ] ⚡ `performance` - Performance improvement
- [ ] 🔨 `refactor` - Code refactoring
- [ ] 🧪 `test` - Adding or updating tests
- [x] 🔧 `chore` - Maintenance, dependencies, tooling
- [x] 🖥️ `backend` - Backend-related changes
- [x] 🎨 `frontend` - Frontend-related changes

## Description

Update @anthropic-ai/claude-code dependency from 1.0.61 to 1.0.77 across all environments (frontend, backend Node.js, and backend Deno). This includes fixing TypeScript compilation errors introduced by new SDK requirements and ensuring consistent dependency versions.

## Changes

- Updated `frontend/package.json` to use @anthropic-ai/claude-code@1.0.77
- Updated `backend/package.json` dependencies and peerDependencies to 1.0.77
- Updated `backend/deno.json` imports to use @anthropic-ai/claude-code@1.0.77
- Fixed TypeScript errors by adding missing `slash_commands: []` property to system messages
- Fixed TypeScript errors by adding missing `permission_denials: []` property to result messages
- Updated package-lock.json and deno.lock files

## Test Plan

- [x] All existing tests pass (frontend: 49 tests, backend: 4 tests)
- [x] TypeScript compilation succeeds without errors  
- [x] Code formatting and linting checks pass
- [x] Quality checks (`make check`) complete successfully
- [x] All dependency versions are consistent across environments

🤖 Generated with [Claude Code](https://claude.ai/code)