### PR TITLE
fix: improve error handling when Claude CLI path detection fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,15 +53,16 @@
 
 ## 📑 Table of Contents
 
-- [✨ Why Claude Code Web UI?](#why-claude-code-web-ui)
-- [🚀 Quick Start](#quick-start)
-- [⚙️ CLI Options](#️-cli-options)
-- [🔧 Development](#development)
-- [🔒 Security Considerations](#security-considerations)
-- [📚 Documentation](#documentation)
-- [❓ FAQ](#faq)
-- [🤝 Contributing](#contributing)
-- [📄 License](#license)
+- [✨ Why Claude Code Web UI?](#-why-claude-code-web-ui)
+- [🚀 Quick Start](#-quick-start)
+- [⚙️ CLI Options](#-cli-options)
+- [🚨 Troubleshooting](#-troubleshooting)
+- [🔧 Development](#-development)
+- [🔒 Security Considerations](#-security-considerations)
+- [📚 Documentation](#-documentation)
+- [❓ FAQ](#-faq)
+- [🤝 Contributing](#-contributing)
+- [📄 License](#-license)
 
 ---
 
@@ -151,22 +152,61 @@ The backend server supports the following command-line options:
 
 ```bash
 # Default (localhost:8080)
-./claude-code-webui
+claude-code-webui
 
 # Custom port
-./claude-code-webui --port 3000
+claude-code-webui --port 3000
 
 # Bind to all interfaces (accessible from network)
-./claude-code-webui --host 0.0.0.0 --port 9000
+claude-code-webui --host 0.0.0.0 --port 9000
 
 # Enable debug mode
-./claude-code-webui --debug
+claude-code-webui --debug
 
 # Custom Claude CLI path (for non-standard installations or aliases)
-./claude-code-webui --claude-path /path/to/claude
+claude-code-webui --claude-path /path/to/claude
 
 # Using environment variables
-PORT=9000 DEBUG=true ./claude-code-webui
+PORT=9000 DEBUG=true claude-code-webui
+```
+
+---
+
+## 🚨 Troubleshooting
+
+### Claude CLI Path Detection Issues
+
+If you encounter "Claude Code process exited with code 1" or similar errors, this typically indicates Claude CLI path detection failure.
+
+**Quick Solution:**
+```bash
+claude-code-webui --claude-path "$(which claude)"
+```
+
+**Common scenarios requiring explicit path specification:**
+- **Node.js environment managers** (Volta, asdf, nvm, etc.)
+- **Custom installation locations**
+- **Shell aliases or wrapper scripts**
+
+**Environment-specific commands:**
+```bash
+# For Volta users
+claude-code-webui --claude-path "$(volta which claude)"
+
+# For asdf users
+claude-code-webui --claude-path "$(asdf which claude)"
+```
+
+**Native Binary Installation:**
+Currently **not supported** due to TypeScript SDK limitations. Please use npm/yarn installation:
+```bash
+npm install -g @anthropic-ai/claude-code
+```
+
+**Debug Mode:**
+Use `--debug` flag for detailed error information:
+```bash
+claude-code-webui --debug
 ```
 
 ---
@@ -242,10 +282,10 @@ PORT=9000 npm run dev       # Node.js
 
 ```bash
 # Local only (recommended)
-./claude-code-webui --port 8080
+claude-code-webui --port 8080
 
 # Network access (trusted networks only)
-./claude-code-webui --port 8080 --host 0.0.0.0
+claude-code-webui --port 8080 --host 0.0.0.0
 ```
 
 **Never expose to public internet without proper security measures.**
@@ -300,9 +340,9 @@ Download the latest binary from releases or pull the latest code for development
 </details>
 
 <details>
-<summary><strong>Q: What if Claude CLI isn't found?</strong></summary>
+<summary><strong>Q: What if Claude CLI isn't found or I get "process exited with code 1"?</strong></summary>
 
-Ensure Claude CLI is installed and available in your PATH. Run `claude --version` to verify. For custom installations or shell aliases (e.g., `alias claude="/path/to/claude"`), use the `--claude-path` option to specify the exact path to your Claude executable.
+These errors typically indicate Claude CLI path detection issues. See the [Troubleshooting](#-troubleshooting) section for detailed solutions including environment manager workarounds and debug steps.
 
 </details>
 

--- a/backend/cli/validation.ts
+++ b/backend/cli/validation.ts
@@ -334,19 +334,11 @@ export async function validateClaudeCli(
         "   This can happen when the Claude CLI installation is incompatible with this application.",
       );
       console.error("");
-      console.error("   Solutions:");
       console.error(
-        "   1. Specify a custom Claude path using: --claude-path /path/to/claude",
-      );
-      console.error("   2. Reinstall Claude CLI from: https://claude.ai/code");
-      console.error(
-        "   3. Ensure Claude CLI and @anthropic-ai/claude-code versions are compatible",
+        "   Try specifying a custom `claude` command path using: --claude-path /path/to/claude",
       );
       console.error("");
       console.error(`   Attempted to detect script path from: ${claudePath}`);
-      if (detection.versionOutput) {
-        console.error(`   Claude CLI version: ${detection.versionOutput}`);
-      }
       exit(1);
     }
   } catch (error) {

--- a/backend/cli/validation.ts
+++ b/backend/cli/validation.ts
@@ -328,14 +328,26 @@ export async function validateClaudeCli(
       }
       return detection.scriptPath;
     } else {
-      // Fallback to the original path if detection fails
-      logger.cli.info(
-        `⚠️  CLI script detection failed, using original path: ${claudePath}`,
+      // Exit with clear error when detection fails
+      console.error("❌ Claude CLI script path detection failed");
+      console.error(
+        "   This can happen when the Claude CLI installation is incompatible with this application.",
       );
+      console.error("");
+      console.error("   Solutions:");
+      console.error(
+        "   1. Specify a custom Claude path using: --claude-path /path/to/claude",
+      );
+      console.error("   2. Reinstall Claude CLI from: https://claude.ai/code");
+      console.error(
+        "   3. Ensure Claude CLI and @anthropic-ai/claude-code versions are compatible",
+      );
+      console.error("");
+      console.error(`   Attempted to detect script path from: ${claudePath}`);
       if (detection.versionOutput) {
-        logger.cli.info(`✅ Claude CLI found: ${detection.versionOutput}`);
+        console.error(`   Claude CLI version: ${detection.versionOutput}`);
       }
-      return claudePath;
+      exit(1);
     }
   } catch (error) {
     console.error("❌ Failed to validate Claude CLI");


### PR DESCRIPTION
## Type of Changes
- [x] 🐛 `bug` - Bug fix (non-breaking change which fixes an issue)
- [x] ✨ `feature` - New feature (non-breaking change which adds functionality)
- [ ] 💥 `breaking` - Breaking change
- [x] 📚 `documentation` - Documentation update
- [ ] ⚡ `performance` - Performance improvement
- [ ] 🔨 `refactor` - Code refactoring
- [ ] 🧪 `test` - Adding or updating tests
- [ ] 🔧 `chore` - Maintenance, dependencies, tooling
- [x] 🖥️ `backend` - Backend-related changes
- [ ] 🎨 `frontend` - Frontend-related changes

## Summary
- Exit with clear error message when CLI script path detection fails instead of falling back to original path
- Provide specific guidance on using `--claude-path` option 
- Replace cryptic runtime errors with immediate, actionable feedback
- Add comprehensive troubleshooting documentation to README

## Changes Made

### Backend (`backend/cli/validation.ts`)
- **Replace fallback logic** with proper error handling that exits the process
- **Enhanced error message** with clear explanation and solution guidance
- **Removed version output** on detection failure to reduce confusion
- **Improved terminology** using "`claude` command path" instead of "Claude path"

### Documentation (`README.md`) 
- **New Troubleshooting section** with dedicated 🚨 emoji for visibility
- **Consolidated FAQ entries** to reference comprehensive troubleshooting section
- **Fixed Table of Contents** anchor links with proper emoji encoding
- **Standardized command examples** (remove unnecessary `./` prefix for npm installs)
- **Document environment manager issues** (Volta, asdf, nvm) with specific solutions
- **Emphasize native binary installer limitations**

## Problem Solved
Previously, when Claude CLI path detection failed, the application would:
1. Log warning: "⚠️ CLI script detection failed, using original path"
2. Fall back to original Claude path
3. Later fail during execution with cryptic "Claude Code process exited with code 1" errors

Now it immediately exits with clear, actionable error messages and users can find detailed solutions in the prominent Troubleshooting section.

## Error Message Improvements

### Before
```
⚠️ CLI script detection failed, using original path: /path/to/claude
[Later during execution]
Claude Code process exited with code 1
```

### After
```
❌ Claude CLI script path detection failed
   This can happen when the Claude CLI installation is incompatible with this application.
   
   Try specifying a custom `claude` command path using: --claude-path /path/to/claude
   
   Attempted to detect script path from: /path/to/claude
```

## Test Plan
- [x] Successful CLI detection continues to work normally
- [x] Failed detection now shows clear error and exits immediately
- [x] Custom path validation (`--claude-path`) continues to work as expected
- [x] All quality checks pass (format, lint, typecheck, tests)
- [x] README formatting and links verified
- [x] Troubleshooting section provides comprehensive guidance

## Related Issues
Fixes #231
Addresses common scenarios described in #225

🤖 Generated with [Claude Code](https://claude.ai/code)