### PR TITLE
feat: implement always-visible permission mode toggle UI

### DIFF
--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useCallback, useState } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { ChevronLeftIcon } from "@heroicons/react/24/outline";
-import type { ChatRequest, ChatMessage, ProjectInfo } from "../types";
+import type {
+  ChatRequest,
+  ChatMessage,
+  ProjectInfo,
+  PermissionMode,
+} from "../types";
 import { useTheme } from "../hooks/useTheme";
 import { useClaudeStreaming } from "../hooks/useClaudeStreaming";
 import { useChatState } from "../hooks/chat/useChatState";
@@ -140,6 +145,7 @@ export function ChatPage() {
       messageContent?: string,
       tools?: string[],
       hideUserMessage = false,
+      overridePermissionMode?: PermissionMode,
     ) => {
       const content = messageContent || input.trim();
       if (!content || isLoading) return;
@@ -170,7 +176,7 @@ export function ChatPage() {
             ...(currentSessionId ? { sessionId: currentSessionId } : {}),
             allowedTools: tools || allowedTools,
             ...(workingDirectory ? { workingDirectory } : {}),
-            permissionMode,
+            permissionMode: overridePermissionMode || permissionMode,
           } as ChatRequest),
         });
 
@@ -316,7 +322,7 @@ export function ChatPage() {
     updatePermissionMode("acceptEdits");
     closePlanModeRequest();
     if (currentSessionId) {
-      sendMessage("accept", allowedTools, true);
+      sendMessage("accept", allowedTools, true, "acceptEdits");
     }
   }, [
     updatePermissionMode,
@@ -330,7 +336,7 @@ export function ChatPage() {
     updatePermissionMode("default");
     closePlanModeRequest();
     if (currentSessionId) {
-      sendMessage("accept", allowedTools, true);
+      sendMessage("accept", allowedTools, true, "default");
     }
   }, [
     updatePermissionMode,

--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -561,6 +561,8 @@ export function ChatPage() {
               onInputChange={setInput}
               onSubmit={() => sendMessage()}
               onAbort={handleAbort}
+              permissionMode={permissionMode}
+              onPermissionModeChange={setPermissionMode}
               showPermissions={isPermissionMode}
               permissionData={permissionData}
               planPermissionData={planPermissionData}
@@ -568,8 +570,6 @@ export function ChatPage() {
           </>
         )}
       </div>
-
-      {/* Permission interface - Now handled inline by ChatInput component */}
     </div>
   );
 }

--- a/frontend/src/components/DemoPage.tsx
+++ b/frontend/src/components/DemoPage.tsx
@@ -430,13 +430,13 @@ export function DemoPage() {
           onInputChange={() => {}} // No-op in demo - intentionally blocks user input to simulate a controlled environment where input is not required or allowed
           onSubmit={handleSendMessage}
           onAbort={() => {}} // No-op in demo
+          permissionMode="default" // Demo always uses default mode
+          onPermissionModeChange={() => {}} // No-op in demo
           showPermissions={isPermissionMode}
           permissionData={permissionData}
           planPermissionData={planPermissionData}
         />
       </div>
-
-      {/* Permission interface - Now handled inline by ChatInput component */}
     </div>
   );
 }

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -148,6 +148,18 @@ export function ChatInput({
     }
   };
 
+  // Get clean permission mode name (without emoji)
+  const getPermissionModeName = (mode: PermissionMode): string => {
+    switch (mode) {
+      case "default":
+        return "normal mode";
+      case "plan":
+        return "plan mode";
+      case "acceptEdits":
+        return "accept edits";
+    }
+  };
+
   // Get next permission mode for cycling
   const getNextPermissionMode = (current: PermissionMode): PermissionMode => {
     const modes: PermissionMode[] = ["default", "plan", "acceptEdits"];
@@ -230,7 +242,7 @@ export function ChatInput({
           onPermissionModeChange(getNextPermissionMode(permissionMode))
         }
         className="w-full px-4 py-1 text-xs text-slate-600 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 font-mono text-left transition-colors cursor-pointer"
-        title={`Current: ${getPermissionModeIndicator(permissionMode).split(" ").slice(1).join(" ")} - Click to cycle`}
+        title={`Current: ${getPermissionModeName(permissionMode)} - Click to cycle`}
       >
         {getPermissionModeIndicator(permissionMode)}
       </button>

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -5,6 +5,7 @@ import { useEnterBehavior } from "../../hooks/useEnterBehavior";
 import { EnterModeMenu } from "./EnterModeMenu";
 import { PermissionInputPanel } from "./PermissionInputPanel";
 import { PlanPermissionInputPanel } from "./PlanPermissionInputPanel";
+import type { PermissionMode } from "../../types";
 
 interface PermissionData {
   patterns: string[];
@@ -45,6 +46,8 @@ interface ChatInputProps {
   onSubmit: () => void;
   onAbort: () => void;
   // Permission mode props
+  permissionMode: PermissionMode;
+  onPermissionModeChange: (mode: PermissionMode) => void;
   showPermissions?: boolean;
   permissionData?: PermissionData;
   planPermissionData?: PlanPermissionData;
@@ -57,6 +60,8 @@ export function ChatInput({
   onInputChange,
   onSubmit,
   onAbort,
+  permissionMode,
+  onPermissionModeChange,
   showPermissions = false,
   permissionData,
   planPermissionData,
@@ -131,6 +136,25 @@ export function ChatInput({
     setTimeout(() => setIsComposing(false), 0);
   };
 
+  // Get permission mode status indicator (CLI-style)
+  const getPermissionModeIndicator = (mode: PermissionMode): string => {
+    switch (mode) {
+      case "default":
+        return "🔧 normal mode";
+      case "plan":
+        return "⏸ plan mode";
+      case "acceptEdits":
+        return "⏵⏵ accept edits";
+    }
+  };
+
+  // Get next permission mode for cycling
+  const getNextPermissionMode = (current: PermissionMode): PermissionMode => {
+    const modes: PermissionMode[] = ["default", "plan", "acceptEdits"];
+    const currentIndex = modes.indexOf(current);
+    return modes[(currentIndex + 1) % modes.length];
+  };
+
   // If we're in plan permission mode, show the plan permission panel instead
   if (showPermissions && planPermissionData) {
     return (
@@ -194,10 +218,22 @@ export function ChatInput({
             disabled={!input.trim() || isLoading}
             className="px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-slate-400 text-white rounded-lg font-medium transition-all duration-200 shadow-sm hover:shadow-md disabled:cursor-not-allowed disabled:opacity-50 text-sm"
           >
-            {isLoading ? "..." : "Send"}
+            {isLoading ? "..." : permissionMode === "plan" ? "Plan" : "Send"}
           </button>
         </div>
       </form>
+
+      {/* Permission mode status bar */}
+      <button
+        type="button"
+        onClick={() =>
+          onPermissionModeChange(getNextPermissionMode(permissionMode))
+        }
+        className="w-full px-4 py-1 text-xs text-slate-600 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 font-mono text-left transition-colors cursor-pointer"
+        title={`Current: ${getPermissionModeIndicator(permissionMode).split(" ").slice(1).join(" ")} - Click to cycle`}
+      >
+        {getPermissionModeIndicator(permissionMode)}
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Type of Change

- [ ] 🐛 `bug` - Bug fix (non-breaking change which fixes an issue)
- [x] ✨ `feature` - New feature (non-breaking change which adds functionality)
- [ ] 💥 `breaking` - Breaking change
- [ ] 📚 `documentation` - Documentation update
- [ ] ⚡ `performance` - Performance improvement
- [ ] 🔨 `refactor` - Code refactoring
- [ ] 🧪 `test` - Adding or updating tests
- [ ] 🔧 `chore` - Maintenance, dependencies, tooling
- [ ] 🖥️ `backend` - Backend-related changes
- [x] 🎨 `frontend` - Frontend-related changes

## Description

Implements a user-friendly permission mode toggle UI to replace the hidden icon-only approach, plus fixes permission mode synchronization issues between frontend and backend.

### UI Improvements
- Always-visible status bar with CLI-style indicators (`🔧 normal mode`, `⏸ plan mode`, `⏵⏵ accept edits`)
- Replaces hidden icon button that users couldn't discover
- Mimics Claude CLI `shift+tab to cycle` behavior for consistency
- Eliminates layout shifts when switching modes
- Status display itself is clickable for intuitive interaction

### Synchronization Fix
- Fixed critical timing issue where plan mode → accept edits selections sent incorrect `permissionMode` to backend
- Root cause: React's asynchronous state updates caused backend to receive stale values
- Solution: Added `overridePermissionMode` parameter to explicitly specify permission mode

## Test Plan

- ✅ TypeScript compilation passes
- ✅ ESLint validation passes
- ✅ All unit tests passing (49/49)
- ✅ Frontend build successful
- ✅ Manual testing of permission mode cycling
- ✅ Backend receives correct permission mode values

## Changes

- `ChatInput.tsx`: Added always-visible clickable status bar
- `ChatPage.tsx`: Enhanced sendMessage with permission mode override
- `DemoPage.tsx`: Updated for new ChatInput props
- Removed unused `PermissionModeToggle.tsx`

Closes #131