### PR TITLE
remove: Select New Directory option from project selector

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -50,18 +50,4 @@ describe("App Routing", () => {
       expect(screen.getByText("/test-path")).toBeInTheDocument();
     });
   });
-
-  it("shows new directory selection button", async () => {
-    render(
-      <MemoryRouter initialEntries={["/"]}>
-        <Routes>
-          <Route path="/" element={<ProjectSelector />} />
-        </Routes>
-      </MemoryRouter>,
-    );
-
-    await waitFor(() => {
-      expect(screen.getByText("Select New Directory")).toBeInTheDocument();
-    });
-  });
 });

--- a/frontend/src/components/ProjectSelector.tsx
+++ b/frontend/src/components/ProjectSelector.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { FolderIcon, PlusIcon } from "@heroicons/react/24/outline";
+import { FolderIcon } from "@heroicons/react/24/outline";
 import type { ProjectsResponse, ProjectInfo } from "../types";
 import { getProjectsUrl } from "../config/api";
 
@@ -35,52 +35,6 @@ export function ProjectSelector() {
       ? projectPath
       : `/${projectPath}`;
     navigate(`/projects${normalizedPath}`);
-  };
-
-  const handleNewDirectory = async () => {
-    if (!window.showDirectoryPicker) {
-      alert("Directory picker not supported in this browser");
-      return;
-    }
-
-    try {
-      const dirHandle = await window.showDirectoryPicker();
-      // Construct path from directory handle
-      // Note: The actual path reconstruction might need adjustment based on browser capabilities
-      const path = await getPathFromHandle(dirHandle);
-      navigate(`/projects${path}`);
-    } catch (err) {
-      if (err instanceof Error && err.name !== "AbortError") {
-        console.error("Failed to select directory:", err);
-      }
-    }
-  };
-
-  // Helper function to reconstruct path from directory handle
-  // This is a simplified version - actual implementation may vary by browser
-  const getPathFromHandle = async (
-    handle: FileSystemDirectoryHandle,
-  ): Promise<string> => {
-    // For now, we'll use the handle name as the directory name
-    // In a real implementation, you might need to reconstruct the full path
-    // This is a browser limitation - full paths are not always available for security reasons
-    const parts: string[] = [];
-    const currentHandle: FileSystemDirectoryHandle | undefined = handle;
-
-    while (currentHandle) {
-      parts.unshift(currentHandle.name);
-      // Note: This is a simplified approach
-      // Getting parent directory is not directly supported in all browsers
-      break;
-    }
-
-    // For local development, we'll prompt user to enter the full path
-    const fullPath = prompt(
-      `Please enter the full path for the selected directory "${handle.name}":`,
-      `/Users/yo-sugi/dev/${handle.name}`,
-    );
-
-    return fullPath || `/${handle.name}`;
   };
 
   if (loading) {
@@ -126,19 +80,8 @@ export function ProjectSelector() {
                   </span>
                 </button>
               ))}
-              <div className="my-6 border-t border-slate-200 dark:border-slate-700" />
             </>
           )}
-
-          <button
-            onClick={handleNewDirectory}
-            className="w-full flex items-center gap-3 p-4 bg-blue-50 dark:bg-blue-900/20 hover:bg-blue-100 dark:hover:bg-blue-900/30 border border-blue-200 dark:border-blue-800 rounded-lg transition-colors text-left"
-          >
-            <PlusIcon className="h-5 w-5 text-blue-600 dark:text-blue-400 flex-shrink-0" />
-            <span className="text-blue-800 dark:text-blue-200 font-medium">
-              Select New Directory
-            </span>
-          </button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Type of Change

- [ ] 🐛 `bug` - Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ `feature` - New feature (non-breaking change which adds functionality)
- [ ] 💥 `breaking` - Breaking change
- [ ] 📚 `documentation` - Documentation update
- [ ] ⚡ `performance` - Performance improvement
- [x] 🔨 `refactor` - Code refactoring
- [ ] 🧪 `test` - Adding or updating tests
- [ ] 🔧 `chore` - Maintenance, dependencies, tooling
- [ ] 🖥️ `backend` - Backend-related changes
- [x] 🎨 `frontend` - Frontend-related changes

## Summary

Removes the impractical "Select New Directory" option from the project selector that relied on the File System Access API.

## Changes

- Remove PlusIcon import and Select New Directory button from ProjectSelector.tsx
- Remove handleNewDirectory and getPathFromHandle functions
- Clean up unused File System Access API code
- Remove test that expected the Select New Directory button
- Simplify JSX structure without the additional option

## Reasoning

The File System Access API has several limitations that make this feature impractical:

- **Limited browser support**: Only works in Chromium-based browsers (Chrome, Edge)
- **Security restrictions**: Requires HTTPS in production environments  
- **Poor UX**: Current implementation requires manual path entry via prompts
- **Path limitations**: Browser security prevents access to full file paths

This change improves UX by focusing on the reliable backend project API instead of browser-dependent directory picking functionality.

## Test Plan

- [x] All existing tests pass
- [x] Project selector displays only available projects from backend API
- [x] No "Select New Directory" button is visible
- [x] Quality checks (lint, format, typecheck) pass

🤖 Generated with [Claude Code](https://claude.ai/code)