### PR TITLE
Add keyboard shortcut for permission mode cycling

### DIFF
--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -97,6 +97,19 @@ export function ChatInput({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // Permission mode toggle: Ctrl+Shift+M (all platforms)
+    if (
+      e.key === KEYBOARD_SHORTCUTS.PERMISSION_MODE_TOGGLE &&
+      e.shiftKey &&
+      e.ctrlKey &&
+      !e.metaKey && // Avoid conflicts with browser shortcuts on macOS
+      !isComposing
+    ) {
+      e.preventDefault();
+      onPermissionModeChange(getNextPermissionMode(permissionMode));
+      return;
+    }
+
     if (e.key === KEYBOARD_SHORTCUTS.SUBMIT && !isComposing) {
       if (enterBehavior === "newline") {
         handleNewlineModeKeyDown(e);
@@ -242,9 +255,12 @@ export function ChatInput({
           onPermissionModeChange(getNextPermissionMode(permissionMode))
         }
         className="w-full px-4 py-1 text-xs text-slate-600 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 font-mono text-left transition-colors cursor-pointer"
-        title={`Current: ${getPermissionModeName(permissionMode)} - Click to cycle`}
+        title={`Current: ${getPermissionModeName(permissionMode)} - Click to cycle (Ctrl+Shift+M)`}
       >
         {getPermissionModeIndicator(permissionMode)}
+        <span className="ml-2 text-slate-400 dark:text-slate-500 text-[10px]">
+          - Click to cycle (Ctrl+Shift+M)
+        </span>
       </button>
     </div>
   );

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -8,6 +8,7 @@ export const UI_CONSTANTS = {
 export const KEYBOARD_SHORTCUTS = {
   ABORT: "Escape",
   SUBMIT: "Enter",
+  PERMISSION_MODE_TOGGLE: "M",
 } as const;
 
 // Message display constants


### PR DESCRIPTION
## Summary
Implement Ctrl+Shift+M keyboard shortcut to cycle through permission modes (normal → plan → acceptEdits → normal) as requested in issue #249.

## Changes
- Add PERMISSION_MODE_TOGGLE constant to constants.ts
- Implement Ctrl+Shift+M keyboard shortcut detection in ChatInput.tsx handleKeyDown function
- Update permission mode status bar to always show 'Click to cycle (Ctrl+Shift+M)' text for better discoverability
- Cross-platform support with IME composition state respect
- Avoid browser shortcut conflicts by excluding metaKey on macOS

## Type of Change
- [x] ✨ feature - New feature (non-breaking change which adds functionality)
- [x] 🎨 frontend - Frontend-related changes

## Technical Details
- Uses existing getNextPermissionMode function for consistent cycling behavior
- Keyboard shortcut works when textarea is focused
- Respects IME composition state (isComposing) to avoid conflicts with input methods
- Status bar text is displayed with subtle styling (text-slate-400 dark:text-slate-500 text-[10px])

## Test Plan
- [x] All existing tests pass
- [x] Code formatting and linting checks pass
- [x] TypeScript compilation succeeds
- Manual testing required for keyboard shortcut functionality

Fixes #249

🤖 Generated with [Claude Code](https://claude.ai/code)