### PR TITLE
ci: add build validation and fix claude-code dependency issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ jobs:
   backend:
     name: Backend
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
     strategy:
       matrix:
         node-version: [20, 22, 24]
@@ -25,10 +28,10 @@ jobs:
           cache-dependency-path: backend/package-lock.json
 
       - name: Install backend dependencies
-        run: cd backend && npm ci
+        run: npm ci
 
       - name: Generate version.ts
-        run: cd backend && node scripts/generate-version.js
+        run: node scripts/generate-version.js
 
       - name: Setup Deno
         uses: denoland/setup-deno@v2
@@ -36,32 +39,41 @@ jobs:
           deno-version: v2.x
 
       - name: Install and cache Deno dependencies
-        run: cd backend && deno install && deno cache cli/deno.ts
+        run: deno install && deno cache cli/deno.ts
 
       - name: Format check (Deno)
-        run: cd backend && deno task format:check
+        run: deno task format:check
 
       - name: Format check (Prettier)
-        run: cd backend && npm run format:check
+        run: npm run format:check
 
       - name: Lint (Deno)
-        run: cd backend && deno task lint
+        run: deno task lint
 
       - name: Lint (ESLint)
-        run: cd backend && npm run lint
+        run: npm run lint
 
       - name: Type check (Deno)
-        run: cd backend && deno task check
+        run: deno task check
 
       - name: Type check (TypeScript)
-        run: cd backend && npm run typecheck
+        run: npm run typecheck
 
       - name: Test
-        run: cd backend && npm run test
+        run: npm run test
+
+      - name: Build backend
+        run: npm run build
+
+      - name: Test built CLI
+        run: node dist/cli/node.js -h
 
   frontend:
     name: Frontend
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
     strategy:
       matrix:
         node-version: [20, 22, 24]
@@ -77,22 +89,22 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install dependencies
-        run: cd frontend && npm ci
+        run: npm ci
 
       - name: Format check
-        run: cd frontend && npm run format:check
+        run: npm run format:check
 
       - name: Lint
-        run: cd frontend && npm run lint
+        run: npm run lint
 
       - name: Type check
-        run: cd frontend && npm run typecheck
+        run: npm run typecheck
 
       - name: Test
-        run: cd frontend && npm test
+        run: npm test
 
       - name: Build
-        run: cd frontend && npm run build
+        run: npm run build
 
   # Summary job for branch protection rules
   ci-success:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Test
         run: npm run test
 
+      - name: Create dummy frontend dist for build
+        run: mkdir -p ../frontend/dist && touch ../frontend/dist/dummy
+
       - name: Build backend
         run: npm run build
 

--- a/backend/deno.json
+++ b/backend/deno.json
@@ -24,7 +24,7 @@
     "node:process": "node:process",
     "commander": "npm:commander@^14.0.0",
     "hono": "jsr:@hono/hono@^4.8.5",
-    "@anthropic-ai/claude-code": "npm:@anthropic-ai/claude-code@1.0.98",
+    "@anthropic-ai/claude-code": "npm:@anthropic-ai/claude-code@1.0.90",
     "@logtape/logtape": "jsr:@logtape/logtape@^1.0.0",
     "@logtape/pretty": "jsr:@logtape/pretty@^1.0.0"
   }

--- a/backend/deno.lock
+++ b/backend/deno.lock
@@ -38,12 +38,12 @@
       "jsr:@logtape/pretty@1",
       "jsr:@std/assert@1",
       "jsr:@std/path@1",
-      "npm:@anthropic-ai/claude-code@1.0.98",
+      "npm:@anthropic-ai/claude-code@1.0.90",
       "npm:commander@14"
     ],
     "packageJson": {
       "dependencies": [
-        "npm:@anthropic-ai/claude-code@1.0.98",
+        "npm:@anthropic-ai/claude-code@1.0.90",
         "npm:@hono/node-server@1",
         "npm:@logtape/logtape@1",
         "npm:@logtape/pretty@1",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "claude-code-webui",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-webui",
-      "version": "0.1.48",
+      "version": "0.1.49",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/claude-code": "1.0.98",
+        "@anthropic-ai/claude-code": "1.0.90",
         "@hono/node-server": "^1.0.0",
         "@logtape/logtape": "^1.0.0",
         "@logtape/pretty": "^1.0.0",
@@ -35,13 +35,13 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@anthropic-ai/claude-code": "1.0.98"
+        "@anthropic-ai/claude-code": "1.0.90"
       }
     },
     "node_modules/@anthropic-ai/claude-code": {
-      "version": "1.0.98",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.98.tgz",
-      "integrity": "sha512-IV193Eh8STdRcN3VkNcojPIlLnQPch+doBVrDSEV1rPPePISy7pzHFZL0Eg7zIPj9gHkHV1D2s0RMMwzVXJThA==",
+      "version": "1.0.90",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.90.tgz",
+      "integrity": "sha512-waC7GC4fnfyiFVFTS7Eo4MAS/iEYpyM67JZFXr+B07bOkjBYtBqXh77+Z/btcyI8NxvUtpnFS0R5FXkU/tKCwg==",
       "license": "SEE LICENSE IN README.md",
       "bin": {
         "claude": "cli.js"

--- a/backend/package.json
+++ b/backend/package.json
@@ -54,7 +54,7 @@
     "prepublishOnly": "npm run build && npm run test"
   },
   "dependencies": {
-    "@anthropic-ai/claude-code": "1.0.98",
+    "@anthropic-ai/claude-code": "1.0.90",
     "@hono/node-server": "^1.0.0",
     "@logtape/logtape": "^1.0.0",
     "@logtape/pretty": "^1.0.0",
@@ -74,6 +74,6 @@
     "vitest": "^2.0.0"
   },
   "peerDependencies": {
-    "@anthropic-ai/claude-code": "1.0.98"
+    "@anthropic-ai/claude-code": "1.0.90"
   }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,7 +15,7 @@
         "react-router-dom": "^7.6.2"
       },
       "devDependencies": {
-        "@anthropic-ai/claude-code": "1.0.98",
+        "@anthropic-ai/claude-code": "1.0.90",
         "@eslint/js": "^9.25.0",
         "@playwright/test": "^1.48.2",
         "@tailwindcss/vite": "^4.1.8",
@@ -63,9 +63,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-code": {
-      "version": "1.0.98",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.98.tgz",
-      "integrity": "sha512-IV193Eh8STdRcN3VkNcojPIlLnQPch+doBVrDSEV1rPPePISy7pzHFZL0Eg7zIPj9gHkHV1D2s0RMMwzVXJThA==",
+      "version": "1.0.90",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.90.tgz",
+      "integrity": "sha512-waC7GC4fnfyiFVFTS7Eo4MAS/iEYpyM67JZFXr+B07bOkjBYtBqXh77+Z/btcyI8NxvUtpnFS0R5FXkU/tKCwg==",
       "dev": true,
       "license": "SEE LICENSE IN README.md",
       "bin": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
     "react-router-dom": "^7.6.2"
   },
   "devDependencies": {
-    "@anthropic-ai/claude-code": "1.0.98",
+    "@anthropic-ai/claude-code": "1.0.90",
     "@eslint/js": "^9.25.0",
     "@playwright/test": "^1.48.2",
     "@tailwindcss/vite": "^4.1.8",


### PR DESCRIPTION
## Summary
- Add backend build step and CLI execution test in CI to catch runtime errors early
- Fix @anthropic-ai/claude-code dependency issue by downgrading to 1.0.90
- Improve CI workflow structure using `working-directory` instead of `cd` commands

## Background
Recent update to @anthropic-ai/claude-code 1.0.98 exports `AbortError` in type definitions but not in runtime, causing build failures that weren't caught by existing CI. Through systematic testing, determined that 1.0.90 is the latest version where `AbortError` is properly exported at runtime.

## Changes

### CI Improvements
- Added "Build backend" and "Test built CLI" steps to backend CI job
- Added dummy frontend/dist creation to resolve copy-frontend.js dependency
- Refactored both backend and frontend jobs to use `defaults.run.working-directory`
- Improved readability and maintainability of CI workflow

### Dependency Fix  
- Downgraded @anthropic-ai/claude-code from 1.0.98 to 1.0.90 across all files:
  - `backend/package.json` (dependencies + peerDependencies)
  - `frontend/package.json` 
  - `backend/deno.json`
- Regenerated all lock files for consistency

## Version Testing Results
- ✅ 1.0.90: AbortError properly exported
- ❌ 1.0.91+: "does not provide an export named AbortError" runtime error

## Test Plan
- [x] CI now catches missing export errors during build validation
- [x] CLI execution test passes with 1.0.90
- [x] All existing quality checks continue to pass
- [x] All Node.js matrix versions (20, 22, 24) tested

🤖 Generated with [Claude Code](https://claude.ai/code)