### PR TITLE
Release for 0.1.51

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.51](https://github.com/sugyan/claude-code-webui/compare/0.1.50...0.1.51) - 2025-09-06
+- Fix CollapsibleDetails tool result display with preview functionality by @sugyan in https://github.com/sugyan/claude-code-webui/pull/266
+- Improve hooks message display by simplifying system message content by @sugyan in https://github.com/sugyan/claude-code-webui/pull/268
+- Update @anthropic-ai/claude-code to v1.0.108 and fix AbortError import by @sugyan in https://github.com/sugyan/claude-code-webui/pull/269
+- Fix Claude CLI validation to use fallback instead of exit on detection failure by @sugyan in https://github.com/sugyan/claude-code-webui/pull/270
+- Update native binary installation description in README by @sugyan in https://github.com/sugyan/claude-code-webui/pull/271
+
 ## [0.1.50](https://github.com/sugyan/claude-code-webui/compare/0.1.49...0.1.50) - 2025-08-31
 - fix: unify message processing pipelines between streaming and history by @sugyan in https://github.com/sugyan/claude-code-webui/pull/262
 - ci: add build validation and fix claude-code dependency issue by @sugyan in https://github.com/sugyan/claude-code-webui/pull/264

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-webui",
-  "version": "0.1.50",
+  "version": "0.1.51",
   "type": "module",
   "description": "Web-based interface for the Claude Code CLI with streaming chat interface",
   "keywords": [


### PR DESCRIPTION
This pull request is for the next release as 0.1.51 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag 0.1.51 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-0.1.50" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Fix CollapsibleDetails tool result display with preview functionality by @sugyan in https://github.com/sugyan/claude-code-webui/pull/266
* Improve hooks message display by simplifying system message content by @sugyan in https://github.com/sugyan/claude-code-webui/pull/268
* Update @anthropic-ai/claude-code to v1.0.108 and fix AbortError import by @sugyan in https://github.com/sugyan/claude-code-webui/pull/269
* Fix Claude CLI validation to use fallback instead of exit on detection failure by @sugyan in https://github.com/sugyan/claude-code-webui/pull/270
* Update native binary installation description in README by @sugyan in https://github.com/sugyan/claude-code-webui/pull/271


**Full Changelog**: https://github.com/sugyan/claude-code-webui/compare/0.1.50...0.1.51