### PR TITLE
Improve hooks message display by simplifying system message content

### DIFF
--- a/frontend/src/components/MessageComponents.tsx
+++ b/frontend/src/components/MessageComponents.tsx
@@ -21,6 +21,21 @@ import {
   isBashToolUseResult,
 } from "../utils/contentUtils";
 
+// ANSI escape sequence regex for cleaning hooks messages
+const ANSI_REGEX = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
+
+// Type guard to check if the message is a hooks message
+function isHooksMessage(
+  msg: SystemMessage,
+): msg is HooksMessage & { timestamp: number } {
+  return (
+    msg.type === "system" &&
+    "content" in msg &&
+    typeof msg.content === "string" &&
+    !("subtype" in msg)
+  );
+}
+
 interface ChatMessageComponentProps {
   message: ChatMessage;
 }
@@ -65,16 +80,6 @@ interface SystemMessageComponentProps {
 export function SystemMessageComponent({
   message,
 }: SystemMessageComponentProps) {
-  // Type guard to check if the message is a hooks message
-  const isHooksMessage = (msg: SystemMessage): msg is HooksMessage => {
-    return (
-      msg.type === "system" &&
-      "content" in msg &&
-      typeof msg.content === "string" &&
-      !("subtype" in msg)
-    );
-  };
-
   // Generate details based on message type and subtype
   const getDetails = () => {
     if (
@@ -102,9 +107,7 @@ export function SystemMessageComponent({
     } else if (isHooksMessage(message)) {
       // This is a hooks message - show only the content
       // Remove ANSI escape sequences for cleaner display
-      const escapeChar = String.fromCharCode(27); // ESC character
-      const ansiRegex = new RegExp(`${escapeChar}\\[[0-9;]*m`, "g");
-      return message.content.replace(ansiRegex, "");
+      return message.content.replace(ANSI_REGEX, "");
     }
     return JSON.stringify(message, null, 2);
   };

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -36,7 +36,6 @@ export type HooksMessage = {
   content: string;
   level?: string;
   toolUseID?: string;
-  timestamp: number;
 };
 
 // System message extending SDK types with timestamp

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -30,12 +30,22 @@ export type AbortMessage = {
   timestamp: number;
 };
 
+// Hooks message for hook execution notifications
+export type HooksMessage = {
+  type: "system";
+  content: string;
+  level?: string;
+  toolUseID?: string;
+  timestamp: number;
+};
+
 // System message extending SDK types with timestamp
 export type SystemMessage = (
   | SDKSystemMessage
   | SDKResultMessage
   | ErrorMessage
   | AbortMessage
+  | HooksMessage
 ) & {
   timestamp: number;
 };


### PR DESCRIPTION
## Summary
- Add HooksMessage type for proper TypeScript support of hooks messages
- Detect hooks messages by checking for type 'system' with string content and no subtype
- Display only the content text instead of full JSON for hooks messages
- Strip ANSI escape sequences for cleaner display

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🔨 Refactor (non-breaking change that doesn't add functionality but improves code)
- [ ] 📚 Documentation (changes to documentation)
- [ ] 🧪 Test (adding missing tests or correcting existing tests)
- [ ] 🔧 Chore (changes to the build process or auxiliary tools)

## Changes
- **frontend/src/types.ts**: Add new `HooksMessage` type for hooks system messages
- **frontend/src/components/MessageComponents.tsx**: 
  - Add type guard `isHooksMessage()` to safely identify hooks messages
  - Show only content string for hooks messages instead of verbose JSON
  - Remove ANSI escape sequences using `String.fromCharCode(27)` approach
  - Fix TypeScript type checking for system message union types

## Hook Types Supported
This applies to all Claude Code hook types:
- PreToolUse, PostToolUse, Notification, UserPromptSubmit
- Stop, SubagentStop, PreCompact, SessionStart, SessionEnd

## Test Plan
- [x] All existing tests pass
- [x] TypeScript compilation succeeds
- [x] ESLint and Prettier checks pass
- [x] Frontend build succeeds

## Before/After
**Before**: `{"type":"system","content":"Running PostToolUse:Edit...","level":"info","toolUseID":"toolu_123","timestamp":123456789}`

**After**: `Running PostToolUse:Edit...`

🤖 Generated with [Claude Code](https://claude.ai/code)