### PR TITLE
Improve release flow with draft releases and OIDC npm publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,6 +135,9 @@ jobs:
   npm-publish:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for OIDC authentication
+      contents: read # Required for repository access
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -177,11 +180,7 @@ jobs:
       - name: Publish to npm (dry-run)
         run: npm publish --dry-run
         working-directory: backend
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish to npm
         run: npm publish
         working-directory: backend
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.tagpr
+++ b/.tagpr
@@ -10,8 +10,8 @@
 	# Use "v" prefix for tags (v1.0.0, v1.0.1, etc.)
 	vPrefix = false
 
-	# Create GitHub Releases automatically
-	release = true
+	# Create GitHub Releases automatically as draft
+	release = draft
 
 	# Version file location - now using package.json
 	versionFile = backend/package.json


### PR DESCRIPTION
## Summary

This PR improves the release workflow by implementing two key security and process enhancements:

1. **Draft Release Flow**: Configure tagpr to create draft releases instead of immediately published ones
2. **OIDC npm Publishing**: Migrate from NPM_TOKEN to OpenID Connect authentication for secure npm publishing

## Type of Change

- [x] 🔧 **chore**: Changes to the build process or auxiliary tools

## Changes Made

### 1. Draft Release Configuration (.tagpr)
- Changed `release = true` to `release = draft`
- tagpr now creates draft releases instead of immediately published ones
- The release.yml workflow publishes the release after adding artifacts
- Provides better separation of concerns and safer release process

### 2. OIDC npm Publishing (.github/workflows/release.yml)
- Added OIDC permissions: `id-token: write` and `contents: read` to npm-publish job
- Removed `NODE_AUTH_TOKEN` environment variable from both dry-run and publish steps
- npm CLI automatically detects OIDC environment for authentication
- Enables automatic provenance attestations for enhanced security
- Eliminates need for long-lived NPM_TOKEN secret management

## Benefits

- **Enhanced Security**: Short-lived, cryptographically signed authentication tokens
- **Automatic Provenance**: Built-in supply chain security with attestations
- **Safer Releases**: Draft releases prevent premature publishing
- **Reduced Token Management**: No more NPM_TOKEN rotation or exposure risks

## Manual Configuration Required

After merging, configure npm Trusted Publisher on npmjs.com:
1. Navigate to https://www.npmjs.com/package/claude-code-webui settings
2. Configure Trusted Publisher for GitHub Actions:
   - Organization: `sugyan`
   - Repository: `claude-code-webui`
   - Workflow: `release.yml`

## Testing

- [x] All CI checks pass
- [x] Workflow configuration validated
- [x] Release process will be verified in next release

🤖 Generated with [Claude Code](https://claude.ai/code)