### PR TITLE
Fix release workflow draft handling and npm OIDC authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,6 +158,9 @@ jobs:
             backend/package-lock.json
             frontend/package-lock.json
 
+      - name: Update npm to latest version
+        run: npm install -g npm@latest
+
       - name: Install backend dependencies
         run: npm ci
         working-directory: backend


### PR DESCRIPTION
## Summary

This PR fixes two critical issues in the release workflow that were causing failures in v0.1.52:

1. **Draft Release Handling**: Fixed "Cannot upload assets to immutable release" error
2. **npm OIDC Authentication**: Added npm version update for Trusted Publishers support

## Type of Change

- [x] 🐛 **bug**: Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 **chore**: Changes to the build process or auxiliary tools

## Root Cause Analysis

### Issue 1: Immutable Release Error
**Problem**: tagpr correctly created draft releases, but `softprops/action-gh-release` with `draft: false` immediately published the release, then failed when trying to upload assets to the now-immutable published release.

**Timeline**:
- 14:39:23Z - tagpr creates draft release ✅
- 14:43:15Z - workflow publishes release
- 14:43:15Z - same workflow tries to upload assets → **FAIL** (immutable)

### Issue 2: npm Authentication Failure  
**Problem**: Node.js 22 ships with npm 10.9.3, but npm Trusted Publishers requires npm 11.5.1+. The workflow attempted OIDC authentication with insufficient npm version.

## Changes Made

### 1. Two-Step Release Process (.github/workflows/release.yml)
```yaml
# Step 1: Upload assets to draft release
- name: Upload release assets
  uses: softprops/action-gh-release@v2
  with:
    files: |
      artifacts/*/*
      frontend/demo-recordings/*.webm
    draft: true  # Keep as draft while uploading
    prerelease: false

# Step 2: Publish release (no file operations)
- name: Publish release
  uses: softprops/action-gh-release@v2
  with:
    generate_release_notes: true
    draft: false  # Now publish the release
    prerelease: false
```

### 2. npm Version Update for OIDC Support
```yaml
- name: Update npm to latest version
  run: npm install -g npm@latest
```

## Benefits

- **Resolves softprops/action-gh-release#653**: Two-step approach avoids immutable release issues
- **Enables OIDC Trusted Publishers**: npm 11.5.1+ supports secure authentication
- **Automatic Provenance**: OIDC enables automatic supply chain attestations
- **Enhanced Security**: Eliminates long-lived NPM_TOKEN dependency

## Manual Configuration Still Required

After merging, configure npm Trusted Publisher on npmjs.com:
1. Navigate to https://www.npmjs.com/package/claude-code-webui settings
2. Configure Trusted Publisher for GitHub Actions:
   - Organization: `sugyan`
   - Repository: `claude-code-webui`
   - Workflow: `release.yml`

## Testing

- [x] All CI checks pass
- [x] Draft release workflow logic validated
- [x] npm version requirement confirmed (Node.js 22 = npm 10.9.3 < 11.5.1)
- [ ] Full release workflow testing (after npm Trusted Publisher setup)

This should resolve both the release asset upload failures and npm publishing authentication issues.

🤖 Generated with [Claude Code](https://claude.ai/code)