### PR TITLE
Fix path encoding for Windows usernames with underscores

### DIFF
--- a/backend/history/pathUtils.ts
+++ b/backend/history/pathUtils.ts
@@ -31,8 +31,8 @@ export async function getEncodedProjectName(
 
     // Convert project path to expected encoded format for comparison
     const normalizedPath = projectPath.replace(/\/$/, "");
-    // Claude converts '/', '\', ':', and '.' to '-'
-    const expectedEncoded = normalizedPath.replace(/[/\\:.]/g, "-");
+    // Claude converts '/', '\', ':', '.', and '_' to '-'
+    const expectedEncoded = normalizedPath.replace(/[/\\:._]/g, "-");
 
     // Find exact match - if not found, return null
     if (entries.includes(expectedEncoded)) {


### PR DESCRIPTION
The Claude CLI converts underscores to hyphens when creating project history directories, but the web UI wasn't handling this correctly. This caused projects to not appear in the UI for Windows users with underscores in their usernames.

Updated the path encoding regex to include underscores in the replacement pattern.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Description

Brief description of the changes in this PR.

## Type of Change

Please add the appropriate label(s) to this PR and check the relevant box(es):

- [x] 🐛 `bug` - Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ `feature` - New feature (non-breaking change which adds functionality)
- [ ] 💥 `breaking` - Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 `documentation` - Documentation update
- [ ] ⚡ `performance` - Performance improvement
- [ ] 🔨 `refactor` - Code refactoring
- [ ] 🧪 `test` - Adding or updating tests
- [ ] 🔧 `chore` - Maintenance, dependencies, tooling

## Changes Made

- List key changes
- Include any breaking changes
- Mention new dependencies or configuration changes

## Testing

- [ ] Tests pass locally (`make test`)
- [ ] Code is formatted (`make format`)
- [ ] Code is linted (`make lint`)
- [ ] Type checking passes (`make typecheck`)
- [ ] All quality checks pass (`make check`)
- [ ] Manual testing performed (describe what was tested)

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added/updated tests for my changes
- [ ] All tests pass

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Additional Notes

Any additional information, dependencies, or context needed for reviewers.
