### PR TITLE
Add Dependabot configuration with cooldown settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  # Frontend npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 14
+
+  # Backend npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 14
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` configuration file
- Configure weekly dependency updates for frontend and backend npm packages
- Set cooldown periods to prevent frequent PR spam:
  - 7 days default cooldown
  - 30 days for major version updates
  - 14 days for minor version updates
- Limit open PRs to 5 for npm packages, 3 for GitHub Actions
- Include GitHub Actions dependency updates

## Test plan
- [ ] Verify the configuration file syntax is valid
- [ ] Confirm Dependabot recognizes the new configuration
- [ ] Monitor that cooldown settings are respected in future updates

🤖 Generated with [Claude Code](https://claude.ai/code)