### PR TITLE
Fix dependabot and tagpr labels conflict

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
       default-days: 7
       semver-major-days: 30
       semver-minor-days: 14
+    labels:
+      - "dependencies"
 
   # Backend npm dependencies
   - package-ecosystem: "npm"
@@ -23,6 +25,8 @@ updates:
       default-days: 7
       semver-major-days: 30
       semver-minor-days: 14
+    labels:
+      - "dependencies"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
@@ -33,3 +37,5 @@ updates:
     open-pull-requests-limit: 3
     cooldown:
       default-days: 7
+    labels:
+      - "dependencies"

--- a/.tagpr
+++ b/.tagpr
@@ -15,3 +15,7 @@
 
 	# Version file location - now using package.json
 	versionFile = backend/package.json
+
+	# Custom labels for version determination (excludes dependabot auto-labels)
+	majorLabels = ["breaking-change", "major-release"]
+	minorLabels = ["feature", "enhancement"]


### PR DESCRIPTION
## Summary

- Configure dependabot to only use "dependencies" label instead of default major/minor/patch labels
- Configure tagpr to use specific labels for version determination (breaking-change, major-release for major; feature, enhancement for minor)  
- This prevents dependabot's automatic major/minor labels from triggering unintended version bumps in tagpr

## Problem

Dependabot automatically assigns `major`/`minor`/`patch` labels based on semver changes, but tagpr uses these same labels to determine version bumping. This caused unintended major version bumps when dependabot PRs with `major` labels were merged.

## Solution

### Dependabot Configuration (`.github/dependabot.yml`)
```yaml
labels:
  - "dependencies"
```
This overrides the default labels and only applies the `dependencies` label.

### tagpr Configuration (`.tagpr`)
```toml
majorLabels = ["breaking-change", "major-release"]
minorLabels = ["feature", "enhancement"]
```
Now only explicit manual labels will trigger major/minor version bumps.

## Test plan

- [ ] Future dependabot PRs should only have `dependencies` label
- [ ] tagpr should only bump patch versions unless explicit feature/breaking-change labels are applied
- [ ] Manual releases with `breaking-change` or `feature` labels should still trigger appropriate version bumps

🤖 Generated with [Claude Code](https://claude.ai/code)