### PR TITLE
Fix release workflow: Generate version.ts before Deno dependency caching

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,15 +31,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - name: Setup Deno
-        uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
-        with:
-          deno-version: v2.x
-
-      - name: Install and cache Deno dependencies
-        run: deno install && deno cache cli/deno.ts
-        working-directory: backend
-
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -61,6 +52,15 @@ jobs:
 
       - name: Generate version.ts
         run: node scripts/generate-version.js
+        working-directory: backend
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
+        with:
+          deno-version: v2.x
+
+      - name: Install and cache Deno dependencies
+        run: deno install && deno cache cli/deno.ts
         working-directory: backend
 
       - name: Build backend binary


### PR DESCRIPTION
## Summary
- Fixes the release workflow failure by reordering build steps
- Ensures version.ts is generated before Deno tries to cache dependencies
- Resolves the "Module not found" error that was breaking releases

## Problem
The release workflow was failing because it attempted to cache Deno dependencies before generating the required `version.ts` file. This caused TypeScript to fail when trying to resolve the import in `args.ts`.

## Solution
Reordered the workflow steps:
1. Node.js setup and frontend build first
2. Generate `version.ts` file 
3. Then setup Deno and cache dependencies
4. Finally build the backend binary

## Test Plan
- [x] Local TypeScript compilation passes after generating version.ts
- [x] Workflow order is logically correct
- [ ] Verify the fix works in actual release workflow

🤖 Generated with [Claude Code](https://claude.ai/code)