### PR TITLE
Release for 0.1.56

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.56](https://github.com/sugyan/claude-code-webui/compare/0.1.55...0.1.56) - 2025-09-18
+- chore(deps): Bump @hono/node-server from 1.17.0 to 1.19.1 in /backend by @dependabot[bot] in https://github.com/sugyan/claude-code-webui/pull/314
+- chore(deps): Bump actions/download-artifact from 4.3.0 to 5.0.0 by @dependabot[bot] in https://github.com/sugyan/claude-code-webui/pull/307
+- chore(deps): Bump actions/setup-node from 4.4.0 to 5.0.0 by @dependabot[bot] in https://github.com/sugyan/claude-code-webui/pull/306
+- chore(deps-dev): Bump esbuild from 0.25.6 to 0.25.9 in /backend by @dependabot[bot] in https://github.com/sugyan/claude-code-webui/pull/312
+- chore(deps-dev): Bump @types/node from 20.19.4 to 24.3.0 in /backend by @dependabot[bot] in https://github.com/sugyan/claude-code-webui/pull/308
+- chore(deps-dev): Bump typescript-eslint from 8.33.1 to 8.42.0 in /frontend by @dependabot[bot] in https://github.com/sugyan/claude-code-webui/pull/313
+- chore(deps-dev): Bump @types/react from 19.1.6 to 19.1.12 in /frontend by @dependabot[bot] in https://github.com/sugyan/claude-code-webui/pull/316
+- Fix release workflow: Generate version.ts before Deno dependency caching by @sugyan in https://github.com/sugyan/claude-code-webui/pull/317
+
 ## [0.1.55](https://github.com/sugyan/claude-code-webui/compare/0.1.54...0.1.55) - 2025-09-18
 - chore(deps): Bump hono from 4.8.5 to 4.9.7 in /backend by @dependabot[bot] in https://github.com/sugyan/claude-code-webui/pull/288
 - chore(deps): Bump esbuild and vitest in /backend by @dependabot[bot] in https://github.com/sugyan/claude-code-webui/pull/289

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-webui",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "type": "module",
   "description": "Web-based interface for the Claude Code CLI with streaming chat interface",
   "keywords": [


### PR DESCRIPTION
This pull request is for the next release as 0.1.56 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag 0.1.56 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-0.1.55" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* chore(deps): Bump @hono/node-server from 1.17.0 to 1.19.1 in /backend by @dependabot[bot] in https://github.com/sugyan/claude-code-webui/pull/314
* chore(deps): Bump actions/download-artifact from 4.3.0 to 5.0.0 by @dependabot[bot] in https://github.com/sugyan/claude-code-webui/pull/307
* chore(deps): Bump actions/setup-node from 4.4.0 to 5.0.0 by @dependabot[bot] in https://github.com/sugyan/claude-code-webui/pull/306
* chore(deps-dev): Bump esbuild from 0.25.6 to 0.25.9 in /backend by @dependabot[bot] in https://github.com/sugyan/claude-code-webui/pull/312
* chore(deps-dev): Bump @types/node from 20.19.4 to 24.3.0 in /backend by @dependabot[bot] in https://github.com/sugyan/claude-code-webui/pull/308
* chore(deps-dev): Bump typescript-eslint from 8.33.1 to 8.42.0 in /frontend by @dependabot[bot] in https://github.com/sugyan/claude-code-webui/pull/313
* chore(deps-dev): Bump @types/react from 19.1.6 to 19.1.12 in /frontend by @dependabot[bot] in https://github.com/sugyan/claude-code-webui/pull/316
* Fix release workflow: Generate version.ts before Deno dependency caching by @sugyan in https://github.com/sugyan/claude-code-webui/pull/317


**Full Changelog**: https://github.com/sugyan/claude-code-webui/compare/0.1.55...tagpr-from-0.1.55